### PR TITLE
Ensure load parity in Marketplace 2.0

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@ import sys; sys.path.insert(0, "vendor")
 
 import state, live_migration
 
-from flask import Flask, request, render_template, session
+from flask import Flask, request, render_template, session, jsonify
 app = Flask(__name__)
 app.secret_key = state.SECRET_KEY
 
@@ -25,6 +25,11 @@ def pull_from_legacy_site():
         permalink=request.args.get("permalink", "")
     )
     return "ok"
+
+# Stub for load test.
+@app.route("/<permalink>")
+def view_listing(permalink):
+    return jsonify(state.Listing.get_by_id(permalink))
 
 # TODO(fatlotus): add App-Engine-less version of the "state" module.
 if __name__ == "__main__":

--- a/static/loadtest.js
+++ b/static/loadtest.js
@@ -1,0 +1,13 @@
+/*
+ * This script ensures that the new site is able to sustain the same level of
+ * load as the old one. It is invoked via script inclusion.
+ */
+window.addEventListener('load', function() {
+    var iframe = document.createElement('iframe');
+    iframe.src = 'https://hosted-caravel.appspot.com' +
+         window.location.pathname;
+    iframe.style.display = 'none';
+
+    var body = document.getElementsByTagName('body')[0];
+    body.appendChild(iframe); 
+});


### PR DESCRIPTION
This very sneaky hack allows us to measure a) web page parity and b) resistance to realistic load. I've added the following tracking code to the bottom of the old page `<head>`:

    <script src="https://hosted-caravel.appspot.com/static/loadtest.js"></script>

We're already replicating database writes... and will see what the next 24 hours have in store for us.