### PR TITLE
Enable remote_api

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -12,3 +12,4 @@ handlers:
 
 builtins:
 - deferred: on
+- remote_api: on

--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@ import sys; sys.path.insert(0, "vendor")
 
 import state, live_migration
 
-from flask import Flask, request, render_template, session
+from flask import Flask, request, render_template, session, jsonify
 app = Flask(__name__)
 app.secret_key = state.SECRET_KEY
 
@@ -25,6 +25,11 @@ def pull_from_legacy_site():
         permalink=request.args.get("permalink", "")
     )
     return "ok"
+
+# Stub for load test.
+@app.route("/<permalink>")
+def view_listing(permalink):
+    return jsonify(state.Listing.get_by_id(permalink))
 
 # TODO(fatlotus): add App-Engine-less version of the "state" module.
 if __name__ == "__main__":

--- a/static/loadtest.js
+++ b/static/loadtest.js
@@ -1,0 +1,13 @@
+/*
+ * This script ensures that the new site is able to sustain the same level of
+ * load as the old one. It is invoked via script inclusion.
+ */
+window.addEventListener('load', function() {
+    var iframe = document.createElement('iframe');
+    iframe.src = 'https://hosted-caravel.appspot.com' +
+         window.location.pathname;
+    iframe.style.display = 'none';
+
+    var body = document.getElementsByTagName('body')[0];
+    body.appendChild(iframe); 
+});


### PR DESCRIPTION
Google App Engine supports a neat feature where local versions of apps have full access to the remote datastore — kinda like tunneled SQL access. Enabling it makes it considerably easier to run ad-hoc updates (such as renaming record keys) without changing the code on the server.