### PR TITLE
Add (cleaner) search caching

### DIFF
--- a/live_migration.py
+++ b/live_migration.py
@@ -6,40 +6,28 @@ import models
 def pull_from_listing(permalink):
     """
     Retrieves the listing from the old Marketplace, and save it to the database.
-    If the pull fails, the code automatically emails an administrator to report
-    it.
     """
 
-    try:
-        # Retrieve existing listing by the permalink.
-        if not re.match(r"^[a-zA-Z\-0-9]+$", permalink):
-            raise ValueError("Invalid permalink: {!r}".format(permalink))
-        url = "http://marketplace.uchicago.edu/{}.json".format(permalink)
-        json_data = json.load(urllib2.urlopen(url))
+    # Retrieve existing listing by the permalink.
+    if not re.match(r"^[a-zA-Z\-0-9]+$", permalink):
+        raise ValueError("Invalid permalink: {!r}".format(permalink))
+    url = "http://marketplace.uchicago.edu/{}.json".format(permalink)
+    json_data = json.load(urllib2.urlopen(url))
 
-        # Parse the listing date from not-quite-ISO8601 to App Engine UTC.
-        posted_at = datetime.datetime.strptime(
-            json_data["renewed_at"][:-6], "%Y-%m-%dT%H:%M:%S"
-        ) - datetime.timedelta(
-            hours=float(json_data["renewed_at"][-6:-3]),
-            minutes=float(json_data["renewed_at"][-2:])
-        )
+    # Parse the listing date from not-quite-ISO8601 to App Engine UTC.
+    posted_at = datetime.datetime.strptime(
+        json_data["renewed_at"][:-6], "%Y-%m-%dT%H:%M:%S"
+    ) - datetime.timedelta(
+        hours=float(json_data["renewed_at"][-6:-3]),
+        minutes=float(json_data["renewed_at"][-2:])
+    )
 
-        # (Idempotently) save this entity into the datastore.
-        models.Listing(
-            id=json_data["permalink"],
-            seller=json_data["seller"]["email"],
-            posted_at=posted_at.replace(tzinfo=None),
-            description=json_data["description"],
-            details=json_data["details"],
-            price=(int(float(json_data["price"]) * 100))
-        ).put()
-
-    except Exception, e:
-        mail.send_mail(
-            "noreply@hosted-caravel.appspotmail.com",
-            "open-source@fatlotus.com",
-            "Automatic Parsing Failed",
-            repr(locals()) + "\n\n" + traceback.format_exc()
-        )
-        raise
+    # (Idempotently) save this entity into the datastore.
+    models.Listing(
+        id=json_data["permalink"],
+        seller=json_data["seller"]["email"],
+        posted_at=posted_at.replace(tzinfo=None),
+        description=json_data["description"],
+        details=json_data["details"],
+        price=(int(float(json_data["price"]) * 100))
+    ).put()

--- a/main.py
+++ b/main.py
@@ -17,13 +17,19 @@ def index():
 
 @app.route("/<permalink>")
 def show(permalink):
-    listing = models.Listing.get_by_id(permalink)
-    return render_template("listing_show.html", listing=listing)
+    listing = search.lookup_listing(permalink)
+    if listing:
+        return render_template("listing_show.html", listing=listing)
+    else:
+        return "404"
 
 @app.route("/<permalink>/edit")
 def form(permalink):
-    listing = models.Listing.get_by_id(permalink)
-    return render_template("listing_form.html", listing=listing)
+    listing = search.lookup_listing(permalink)
+    if listing:
+        return render_template("listing_form.html", listing=listing)
+    else:
+        return "404"
 
 @app.route("/_pull")
 def pull_from_legacy_site():

--- a/main.py
+++ b/main.py
@@ -33,6 +33,10 @@ def pull_from_legacy_site():
     )
     return "ok"
 
+@app.route("/favicon.ico")
+def block_favicons():
+    return "go away"
+
 # Run a debug server if running locally.
 if __name__ == "__main__":
     app.run(debug=True)

--- a/models.py
+++ b/models.py
@@ -1,19 +1,19 @@
 import os
 
-from google.appengine.ext import ndb, deferred
+from google.appengine.ext import db, deferred
 from google.appengine.api import taskqueue
 
-class Listing(ndb.Model):
-    seller = ndb.StringProperty() # an email address
-    description = ndb.StringProperty()
-    details = ndb.TextProperty()
-    price = ndb.IntegerProperty() # in cents of a U.S. dollar
-    posted_at = ndb.DateTimeProperty() # set to None iff not yet published
+class Listing(db.Model):
+    seller = db.StringProperty() # an email address
+    description = db.StringProperty()
+    details = db.TextProperty()
+    price = db.IntegerProperty() # in cents of a U.S. dollar
+    posting_time = db.FloatProperty() # set to 0 iff not yet published
 
-class SharedSecret(ndb.Model):
-    value = ndb.BlobProperty()
+class SharedSecret(db.Model):
+    value = db.BlobProperty()
 
-SECRET_KEY = SharedSecret.get_or_insert('session_key',
+SECRET_KEY = SharedSecret.get_or_insert(key_name='session_key',
                  value=os.urandom(256)).value
 
 def run_later(task, *vargs, **kwargs):

--- a/search.py
+++ b/search.py
@@ -1,4 +1,4 @@
 import models
 
 def run_query(query):
-    return models.Listing.query().order(models.Listing.posted_at)
+    return models.Listing.all().order("-posting_time")

--- a/search.py
+++ b/search.py
@@ -1,4 +1,9 @@
 import models
 
+from google.appengine.ext import db
+
+def lookup_listing(permalink):
+    return models.Listing.get_by_key_name(permalink)
+
 def run_query(query):
-    return models.Listing.all().order("-posting_time")
+    return models.Listing.all().order("posting_time")

--- a/search.py
+++ b/search.py
@@ -1,9 +1,82 @@
 import models
 
+from google.appengine.api import memcache
 from google.appengine.ext import db
+import itertools, json, logging
 
+def cached(function):
+    """
+    A decorator to add inline caching behavior to a function.
+    """
+
+    def inner(*vargs, **kwargs):
+        """
+        Runs the given function with the cache as a backing.
+        """
+
+        # Generate a memcache key from the arguments and function name.
+        key = json.dumps([function.__name__, vargs, kwargs])
+
+        # Retrieve from cache.
+        serialized = memcache.get(key)
+        if serialized:
+            result = json.loads(serialized)
+            if result:
+                return result
+
+        # Generate and write back to cache.
+        logging.warning("Cache miss: " + key)
+        value = function(*vargs, **kwargs)
+        if value:
+            memcache.set(key, json.dumps(value), time=3600) # 1 hour
+        return value
+    
+    def invalidate(*vargs, **kwargs):
+        """
+        Ensures that the next invocation with these args is not cached.
+        """
+
+        # Generate a memcache key from the arguments and function name.
+        key = json.dumps([function.__name__, vargs, kwargs])
+        memcache.delete(key)
+
+    inner.invalidate = invalidate
+    return inner
+
+@cached
 def lookup_listing(permalink):
-    return models.Listing.get_by_key_name(permalink)
+    """
+    Retrieves a listing by permalink.
+    """
 
-def run_query(query):
-    return models.Listing.all().order("posting_time")
+    ent = models.Listing.get_by_key_name(permalink)
+    if not ent:
+        return None
+    json_dict = db.to_dict(ent)
+    json_dict["key"] = permalink
+    return json_dict
+
+def invalidate_listing(permalink):
+    """
+    Marks the cache as having lost the given listing.
+    """
+
+    lookup_listing.invalidate(permalink)
+    fetch_shard.invalidate("")
+
+@cached
+def fetch_shard(shard=""):
+    """
+    Retrieves the permalinks of all listings to appear on the home page.
+    """
+
+    query = models.Listing.all(keys_only=True).order("posting_time")
+    return [k.name() for k in query.fetch(30)]
+
+def run_query(query=""):
+    """
+    Performs a search query over all listings.
+    """
+
+    keys = fetch_shard("") # TODO: add actual query handling
+    return [lookup_listing(key) for key in keys]

--- a/static/loadtest.js
+++ b/static/loadtest.js
@@ -3,9 +3,21 @@
  * load as the old one. It is invoked via script inclusion.
  */
 window.addEventListener('load', function() {
+    var categories = [
+        'apartments', 'subleases', 'appliances', 'bikes', 'books', 'cars',
+        'electronics', 'employment', 'furniture', 'miscellaneous', 'services',
+        'wanted', 'free'
+    ];
+
+    var path = window.location.pathname.substring(1);
+    if (categories.indexOf(path) >= 0)
+        path = '?q=' + path;
+
+    if (path.startsWith("users"))
+        return;
+
     var iframe = document.createElement('iframe');
-    iframe.src = 'https://hosted-caravel.appspot.com' +
-         window.location.pathname;
+    iframe.src = 'https://hosted-caravel.appspot.com/' + path;
     iframe.style.display = 'none';
 
     var body = document.getElementsByTagName('body')[0];

--- a/templates/index.html
+++ b/templates/index.html
@@ -19,7 +19,7 @@
             <h3 class="panel-title">{{ listing.description }}</h3>
           </div>
           <div class="panel-image hide-panel-body">
-            <a href="/{{ listing.key.id() }}">
+            <a href="/{{ listing.key }}">
               <img
                 src="http://666a658c624a3c03a6b2-25cda059d975d2f318c03e90bcf17c40.r92.cf1.rackcdn.com/unsplash_52d09387ae003_1.JPG"
                 class="panel-image-preview"/>


### PR DESCRIPTION
Not only do the commits make more sense, the code does, too. Please let me know if you have any questions.

Since it's also performance related, I removed the old emailing feature (since the App Engine console has a fancy new exception livestream view), and add a check for /favicon.ico, a file loaded by the browser on every request (!). SInce this would trigger an additional cache miss, it seemed pertinent.

With regard to searching: I'm thinking of making a series of "shards" (lists of keys) where each list contains all the entities with the given word. That way, a search becomes a two-step process: a) (in parallel) look up shards, and b) look up keys for the first N shards. That should be enough, but we'll need to figure out pagination, as well.

I also switched from the New DB to just DB for the backend. It stores things in the same place, just doesn't make as many guesses about how to handle caching.