### PR TITLE
Fix styling on mobile

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -13,7 +13,7 @@
       {% if loop.index is divisibleby(4) %}
         <div class="row">
       {%  endif %}
-      <div class="col-xs-6 col-md-3">
+      <div class="col-xs-12 col-md-3">
         <div class="panel panel-default">
           <div class="panel-heading">
             <h3 class="panel-title">{{ listing.description }}</h3>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -3,6 +3,8 @@
 <head lang="en">
   {% block head %}
     <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
     <link rel="stylesheet" href="/static/default.css"/>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>


### PR DESCRIPTION
This adds: an a) `<meta name="viewport">` tag telling the browser to the native pixels; and b) styling that makes images full width.