### PR TITLE
removing <p> and </p> tags from json scraper

### DIFF
--- a/live_migration.py
+++ b/live_migration.py
@@ -32,7 +32,8 @@ def pull_from_listing(permalink):
         key_name=json_data["permalink"],
         seller=json_data["seller"]["email"],
         posting_time=posting_time,
-        description=json_data["description"],
+        description=re.sub(r'(<a.*>\n*)', '', json_data["description"].replace("<p>", "").replace("</p>", ""))
+        .replace,
         details=json_data["details"],
         price=(int(float(json_data["price"]) * 100))
     ).put()


### PR DESCRIPTION
fixes #16 

I think paragraph tags are the only things that are showing up in the description so that is all I removed. 