### PR TITLE
Fix syntax error in live_migration.py and typo in photos.py

### DIFF
--- a/live_migration.py
+++ b/live_migration.py
@@ -36,8 +36,7 @@ def pull_from_listing(permalink):
         key_name=json_data["permalink"],
         seller=json_data["seller"]["email"],
         posting_time=posting_time,
-        description=re.sub(r'(<a.*>\n*)', '', json_data["description"].replace("<p>", "").replace("</p>", ""))
-        .replace,
+        description=re.sub(r'(<a.*>\n*)', '', json_data["description"].replace("<p>", "").replace("</p>", "")),
         details=json_data["details"],
         price=(int(float(json_data["price"]) * 100))
     )

--- a/photos.py
+++ b/photos.py
@@ -59,7 +59,7 @@ def upload(file_object, size='medium'):
         filename="/{}/{}".format(GCS_BUCKET, photo_id),
         mode="w",
         content_type="image/jpg",
-        options={"x-goog-acl": "public"}
+        options={"x-goog-acl": "public-read"}
     )
     output_file.write(result_data)
     output_file.close()


### PR DESCRIPTION
Since we've both just made goofs that made it into "production," I'm going to try and set up a continuous deployment script, so that branches are automatically deployed to App Engine. That will save us time and help prevent these bugs in the future.

In the interim, please read over these changes :)