### PR TITLE
Make cache return entities instead of dicts

### DIFF
--- a/caravel/storage/cache.py
+++ b/caravel/storage/cache.py
@@ -2,8 +2,49 @@
 The cache uses memcached to dramatically reduce the number of database queries.
 """
 
-import functools, logging, json, os
+import functools, logging, json, os, sys
+from json import JSONEncoder, JSONDecoder
+
 from google.appengine.api import memcache
+from google.appengine.ext import db
+from google.appengine.datastore.entity_pb import EntityProto
+
+class DBEncoder(JSONEncoder):
+    """Packs an entity as a JSON record."""
+
+    def default(self, obj):
+        """Converts an object to a JSON-compatible type."""
+
+        # Pack entities as JSON Objects.
+        if isinstance(obj, db.Model):
+            record, klass = db.to_dict(obj), obj.__class__
+            record["__ent__"] = (klass.__module__, klass.__name__)
+            if obj.is_saved():
+                record["key_name"] = obj.key().name()
+            return record
+
+        return obj
+
+class DBDecoder(JSONDecoder):
+    """Unpacks an entity from a JSON record."""
+
+    def __init__(self, *vargs, **kwargs):
+        """Initialize this JSONDecoder."""
+
+        super(DBDecoder, self).__init__(
+            object_hook=self.object_hook, *vargs, **kwargs)
+
+    def object_hook(self, obj):
+        """Parse this object from JSON."""
+
+        # If we have an entity-like dict, unpack it.
+        if type(obj) is dict and "__ent__" in obj:
+            module, kind = obj["__ent__"]
+            del obj["__ent__"]
+            klass = getattr(sys.modules[module], kind)
+            return klass(**obj)
+
+        return obj
 
 def cache(function):
     """
@@ -23,7 +64,7 @@ def cache(function):
         # Retrieve from cache.
         serialized = memcache.get(key)
         if serialized:
-            result = json.loads(serialized)
+            result = DBDecoder().decode(serialized)
             if result:
                 return result
 
@@ -31,7 +72,7 @@ def cache(function):
         logging.warning("Cache miss: " + key)
         value = function(*vargs, **kwargs)
         if value:
-            memcache.set(key, json.dumps(value), time=3600) # 1 hour
+            memcache.set(key, DBEncoder().encode(value), time=3600) # 1 hour
         return value
 
     def invalidate(*vargs, **kwargs):

--- a/caravel/storage/entities.py
+++ b/caravel/storage/entities.py
@@ -26,8 +26,7 @@ class DerivedProperty(db.Property):
         return self.derive_func(model_instance)
 
     def __set__(self, model_instance, value):
-        """Block assignment to entity.prop."""
-        raise db.DerivedPropertyError("cannot assign to a DerivedProperty")
+        """Ignore assignment to entity.prop."""
 
 class Versioned(db.Expando):
     version = db.IntegerProperty(default=1)
@@ -66,6 +65,10 @@ class Listing(Versioned):
 
     photos_ = db.StringListProperty(indexed=False, name="photos")
     thumbnail_url = db.StringProperty(indexed=False)
+
+    @property
+    def permalink(self):
+        return self.key().name()
 
     @DerivedProperty
     def keywords(self):

--- a/caravel/storage/helpers.py
+++ b/caravel/storage/helpers.py
@@ -8,21 +8,7 @@ def lookup_listing(permalink):
     Retrieves a listing by permalink.
     """
 
-    ent = entities.Listing.get_by_key_name(permalink)
-    if not ent:
-        return None
-    ent.migrate()
-    json_dict = db.to_dict(ent)
-    json_dict["key"] = permalink
-    json_dict["photo_urls"] = ent.photo_urls # FIXME: handle getters better
-
-    # FIXME: remove below once all listings are migrated to new schema
-    if not json_dict.get("title"):
-        json_dict["title"] = json_dict.get("description")
-    if not json_dict.get("body"):
-        json_dict["body"] = json_dict.get("details")
-
-    return json_dict
+    return entities.Listing.get_by_key_name(permalink)
 
 def invalidate_listing(permalink, keywords=[]):
     """
@@ -64,6 +50,6 @@ def run_query(query=""):
 
     # Find the listings for those keys.
     listings = [lookup_listing(key) for key in keys]
-    listings.sort(key=lambda x: -x["posting_time"])
+    listings.sort(key=lambda x: -x.posting_time)
 
     return listings

--- a/caravel/templates/index.html
+++ b/caravel/templates/index.html
@@ -5,13 +5,13 @@
     {% for listing in listings %}
     <div class="listing col-xs-12 col-md-3">
       <h3 class="title">
-        <a href="/{{ listing.key }}?q={{ request.args['q']}}">
+        <a href="/{{ listing.permalink }}?q={{ request.args['q']}}">
           {{ listing.title }}
         </a>
       </h3>
       <p class="price">{{ '${:,.2f}'.format(listing.price / 100) }}</p>
       <p class="age">{{ listing.posting_time | as_duration }}</p>
-      <a href="/{{ listing.key }}?q={{ request.args['q']}}">
+      <a href="/{{ listing.permalink }}?q={{ request.args['q']}}">
         {% if listing.thumbnail_url %}
         <img
             src="{{ listing.thumbnail_url | public_url }}"

--- a/caravel/testing/integration_test.py
+++ b/caravel/testing/integration_test.py
@@ -22,13 +22,13 @@ def run_integration_test():
 
     # Verify that the listing was created.
     data = helpers.lookup_listing("listing-a")
-    if (data["key"] != "listing-a" or
-        data["title"] != "my fancy sublet" or
-        data["body"] != "description here" or
-        data["price"] != 123456 or
-        len(data["photos"]) != 2 or
-        data["posting_time"] != 1441609780.0 or
-        data["seller"] != "seller@uchicago.edu"):
+    if (data.key().name() != "listing-a" or
+        data.title != "my fancy sublet" or
+        data.body != "description here" or
+        data.price != 123456 or
+        len(data.photo_urls) != 2 or
+        data.posting_time != 1441609780.0 or
+        data.seller != "seller@uchicago.edu"):
 
         raise ValueError("migration failed")
 


### PR DESCRIPTION
This was really bugging me :/

Largely, this just simplifies the way we handle this stuff in `caravel/storage/helpers.py` — and also makes adding helpers like these easier in the future.