### PR TITLE
Load more entries when near the end

### DIFF
--- a/caravel/controllers/listings.py
+++ b/caravel/controllers/listings.py
@@ -25,7 +25,7 @@ def search_listings():
 
     # Compute the results matching that query.
     listings = helpers.run_query(query)
-    listings = itertools.islice(listings, offset, offset + 30)
+    listings = itertools.islice(listings, offset, offset + 24)
 
     # Render a chrome-less template for AJAH continuation.
     template = ("" if "continuation" not in request.args else "_continuation")

--- a/caravel/controllers/listings.py
+++ b/caravel/controllers/listings.py
@@ -6,6 +6,7 @@ import uuid, time
 
 from flask import render_template, request, abort, redirect, url_for, session
 from forms import BuyerForm, SellerForm
+import itertools
 
 from google.appengine.api import mail
 
@@ -15,8 +16,20 @@ from caravel.storage import helpers, entities
 @app.route("/")
 def search_listings():
     """Display a list of listings that match the given query."""
-    listings = helpers.run_query(request.args.get("q", ""))
-    return render_template("index.html", listings=listings)
+
+    # Parse filtering options from query.
+    query = request.args.get("q", "")
+    offset = int(request.args.get("offset", "0"))
+    if offset < 0:
+        offset = 0
+
+    # Compute the results matching that query.
+    listings = helpers.run_query(query)
+    listings = itertools.islice(listings, offset, offset + 30)
+
+    # Render a chrome-less template for AJAH continuation.
+    template = ("" if "continuation" not in request.args else "_continuation")
+    return render_template("index{}.html".format(template), listings=listings)
 
 @app.route("/<permalink>", methods=['GET', 'POST'])
 def show_listing(permalink):

--- a/caravel/static/js/continuation.js
+++ b/caravel/static/js/continuation.js
@@ -1,0 +1,77 @@
+/**
+ * The coalesce function ensures that only one invocation of the given function
+ * is in flight. When invoked, the first parameter of +action+ is called with
+ * a function that allows future invocations to succeed.
+ *
+ * @param {Function} action What function to wrap.
+ * @returns {Function} A transformed function
+ */
+var coalesce = function(action) {
+    var active = false;
+
+    return function() {
+        if (active)
+            return;
+
+        action.apply(null, [function() {
+            active = false;
+        }].concat(arguments));
+        active = true;
+    };
+}
+
+/**
+ * Loads more listings from the server.
+ */
+var fetchMore = coalesce(function(complete) {
+
+    // Reconstruct the current query.
+    var searchQuery = "";
+    var frags = window.location.search.split("?");
+    for (var i = 0; i < frags.length; i++) {
+        if (frags[i].startsWith("q="))
+            searchQuery = frags[i];
+    }
+
+    searchQuery += "&continuation";
+    searchQuery += "&offset=" + document.querySelectorAll(".listing").length;
+
+    // Make a background AJAH request.
+    var xhr = new XMLHttpRequest;
+    xhr.open("GET", "?" + searchQuery, true);
+    xhr.onreadystatechange = function() {
+
+        // Ignore events for incomplete requests.
+        if (xhr.readyState != 4)
+            return;
+
+        // Stop fetching more events if we have nothing to fetch.
+        if (xhr.responseText.trim() == "")
+            return;
+
+        // Append the results to the existing results <div>
+        var frag = document.createElement("div");
+        frag.innerHTML = xhr.responseText;
+
+        var listings = document.querySelector("#listings");
+        listings.appendChild(frag);
+
+        // Prevent too many requests from overloading the server.
+        setTimeout(complete, 100);
+    }
+    xhr.send();
+
+});
+
+/*
+ * Load more listings if we're near the end.
+ */
+window.addEventListener("scroll", function() {
+    var total = document.documentElement.scrollHeight;
+    var above = window.scrollY;
+    var viewport = window.innerHeight;
+    var below = total - above - viewport;
+
+    if (below < 5000)
+        fetchMore();
+});

--- a/caravel/storage/helpers.py
+++ b/caravel/storage/helpers.py
@@ -1,6 +1,7 @@
 from caravel.storage import entities
 from caravel.storage.cache import cache
 from google.appengine.ext import db
+import heapq
 
 @cache
 def lookup_listing(permalink):
@@ -29,9 +30,9 @@ def fetch_shard(shard=""):
     query = entities.Listing.all(keys_only=True).order("-posting_time")
     if shard:
         query = query.filter("keywords =", shard)
-    return [k.name() for k in query.fetch(30)]
+    return [k.name() for k in query]
 
-def run_query(query=""):
+def run_query(query="", offset=0):
     """
     Performs a search query over all listings.
     """
@@ -43,14 +44,18 @@ def run_query(query=""):
     words = words[:5] # TODO: Raise once we know the approximate cost.
 
     # Retrieve the keys for entities that match all terms.
-    shards = [set(fetch_shard(entities.fold_query_term(w))) for w in words]
+    shards = [fetch_shard(entities.fold_query_term(w)) for w in words]
     if not shards:
-        return []
-    keys = shards[0].intersection(*shards[1:])
+        return # yields empty generator
 
-    # Find the listings for those keys.
-    listings = [lookup_listing(key) for key in keys]
-    listings.sort(key=lambda x: -x.posting_time)
-    listings = filter(lambda x: x.posting_time, listings)
+    # Load each key from all shards lazily.
+    def _load(keys):
+        for key in keys:
+            listing = lookup_listing(key)
+            if listing and listing.posting_time:
+                yield (listing.posting_time, listing)
 
-    return listings
+    # Merge all shards together via mergesort.
+    merged = heapq.merge(*[_load(shard) for shard in shards])
+    for _, listing in merged:
+        yield listing

--- a/caravel/templates/index.html
+++ b/caravel/templates/index.html
@@ -1,30 +1,13 @@
 {% extends "layout.html" %}
 {% block title %}Listings{% endblock %}
+{% block head %}
+  {{ super() }}
+  <script src="/static/js/continuation.js" type="text/javascript"></script>
+{% endblock %}
 {% block content %}
-  <div class="row">
+  <div class="row" id="listings">
     {% for listing in listings %}
-    <div class="listing col-xs-12 col-md-3">
-      <h3 class="title">
-        <a href="/{{ listing.permalink }}?q={{ request.args['q']}}">
-          {{ listing.title }}
-        </a>
-      </h3>
-      <p class="price">{{ '${:,.2f}'.format(listing.price / 100) }}</p>
-      <p class="age">{{ listing.posting_time | as_duration }}</p>
-      <a href="/{{ listing.permalink }}?q={{ request.args['q']}}">
-        {% if listing.thumbnail_url %}
-        <img
-            src="{{ listing.thumbnail_url | public_url }}"
-            class="panel-image-preview"/>
-        {% else %}
-        <span class="small-image-placeholder">
-          {{ listing.title[:1].upper() }}
-        </span>
-        {% endif %}
-      </a>
-    </div>
+      {% include "listings/inline.html" %}
     {% endfor %}
   </div>
-
-  {# TODO (georgeteo): infinite scroll     #}
 {% endblock %}

--- a/caravel/templates/index_continuation.html
+++ b/caravel/templates/index_continuation.html
@@ -1,0 +1,3 @@
+{% for listing in listings %}
+  {% include "listings/inline.html" %}
+{% endfor %}

--- a/caravel/templates/listing_show.html
+++ b/caravel/templates/listing_show.html
@@ -1,4 +1,3 @@
-{% import "bootstrap/wtf.html" as wtf %}
 {% extends "layout.html" %}
 {% block title %} {% endblock %}
 {% block head %}
@@ -7,60 +6,5 @@
 {% block content %}
   <h2> View Listing </h2>
   <a href="/?q={{ request.args['q'] }}">Back to listings</a>
-  <div class="row">
-    <div class="col-md-6">
-      <div id="carousel-example-generic" class="carousel slide" data-ride="carousel">
-        <div class="carousel-inner" role="listbox">
-        {% set i =0 %}
-        {% for photo in listing.photo_urls %}
-          {% if i == 0 %}
-            <div class="item active">
-          {% else %}
-            <div class="item">
-          {% endif %}
-
-          {% if photo %}
-            <img src="{{ photo | public_url }}">
-          {% else %}
-            <div class="large-image-placeholder">
-              {{ listing.body[:1].upper() }}
-            </div>
-          {% endif %}
-
-{#          Folloring div closes item active or item#}
-          </div>
-        {% set i = i + 1 %}
-        {% endfor %}
-        </div>
-        <a class="left carousel-control" href="#carousel-example-generic" role="button" data-slide="prev">
-          <span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
-          <span class="sr-only">Previous</span>
-        </a>
-        <a class="right carousel-control" href="#carousel-example-generic" role="button" data-slide="next">
-          <span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
-          <span class="sr-only">Next</span>
-        </a>
-      </div>
-    </div>
-    <div class="col-md-6">
-      <h3>{{ listing.title }}</h3>
-      <p>{{ '$%0.2f'|format(listing.price / 100) }}</p>
-      <p>{{ listing.body }}</p>
-      <hr>
-      <button class="btn btn-default dropdown-toggle" type="button" id="dropdown_menu_user" data-toggle="dropdown"
-              aria-haspopup="true" aria-expanded="true">
-        Make an Inquiry
-        <span class="caret"></span>
-      </button>
-      <ul class="dropdown-menu dropdown-form-buyer">
-        <li>
-          <div class="row">
-            <div class="col-md-12">
-              {{ wtf.quick_form(buyer_form) }}
-            </div>
-          </div>
-        </li>
-      </ul>
-    </div>
-  </div>
+  {% include "listings/fullpage.html" %}
 {% endblock %}

--- a/caravel/templates/listings/fullpage.html
+++ b/caravel/templates/listings/fullpage.html
@@ -1,0 +1,58 @@
+{% import "bootstrap/wtf.html" as wtf %}
+
+<div class="row">
+  <div class="col-md-6">
+    <div id="carousel-example-generic" class="carousel slide" data-ride="carousel">
+      <div class="carousel-inner" role="listbox">
+      {% set i =0 %}
+      {% for photo in listing.photo_urls %}
+        {% if i == 0 %}
+          <div class="item active">
+        {% else %}
+          <div class="item">
+        {% endif %}
+
+        {% if photo %}
+          <img src="{{ photo | public_url }}">
+        {% else %}
+          <div class="large-image-placeholder">
+            {{ listing.body[:1].upper() }}
+          </div>
+        {% endif %}
+
+{#          Folloring div closes item active or item#}
+        </div>
+      {% set i = i + 1 %}
+      {% endfor %}
+      </div>
+      <a class="left carousel-control" href="#carousel-example-generic" role="button" data-slide="prev">
+        <span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
+        <span class="sr-only">Previous</span>
+      </a>
+      <a class="right carousel-control" href="#carousel-example-generic" role="button" data-slide="next">
+        <span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
+        <span class="sr-only">Next</span>
+      </a>
+    </div>
+  </div>
+  <div class="col-md-6">
+    <h3>{{ listing.title }}</h3>
+    <p>{{ '$%0.2f'|format(listing.price / 100) }}</p>
+    <p>{{ listing.body }}</p>
+    <hr>
+    <button class="btn btn-default dropdown-toggle" type="button" id="dropdown_menu_user" data-toggle="dropdown"
+            aria-haspopup="true" aria-expanded="true">
+      Make an Inquiry
+      <span class="caret"></span>
+    </button>
+    <ul class="dropdown-menu dropdown-form-buyer">
+      <li>
+        <div class="row">
+          <div class="col-md-12">
+            {{ wtf.quick_form(buyer_form) }}
+          </div>
+        </div>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/caravel/templates/listings/inline.html
+++ b/caravel/templates/listings/inline.html
@@ -1,0 +1,20 @@
+<div class="listing col-xs-12 col-md-3">
+  <h3 class="title">
+    <a href="/{{ listing.permalink }}?q={{ request.args['q']}}">
+      {{ listing.title }}
+    </a>
+  </h3>
+  <p class="price">{{ '${:,.2f}'.format(listing.price / 100) }}</p>
+  <p class="age">{{ listing.posting_time | as_duration }}</p>
+  <a href="/{{ listing.permalink }}?q={{ request.args['q']}}">
+    {% if listing.thumbnail_url %}
+    <img
+        src="{{ listing.thumbnail_url | public_url }}"
+        class="panel-image-preview"/>
+    {% else %}
+    <span class="small-image-placeholder">
+      {{ listing.title[:1].upper() }}
+    </span>
+    {% endif %}
+  </a>
+</div>


### PR DESCRIPTION
It's a fairly involved update, but I think the result is worth it. Please let me know if anything looks funny.

Note that this exposes some of the problems we have on misses — because they're not parallelized, it will sometimes take almost 3s to render the fragment. There's stuff we can do to improve this, but it seemed out of scope.

Tagging with #11.