### PR TITLE
Re-update replication endpoint because Ruby is hard

### DIFF
--- a/caravel/daemons/replication.py
+++ b/caravel/daemons/replication.py
@@ -9,7 +9,7 @@ from caravel.storage import entities, helpers
 from google.appengine.ext import deferred
 from google.appengine.api import taskqueue, urlfetch
 
-@app.route("/_pull", methods=["POST"])
+@app.route("/_pull", methods=["GET"])
 def pull_from_legacy_site():
     """A webhook triggered by the old site that pulls that site."""
     deferred.defer(


### PR DESCRIPTION
The code in the production version now uses OpenURI (which handles redirects and HTTPS) — but it only does GET. As a result, we now need to revert back to GET in order to properly handle _pull requests. (Also WTForms requires CSRF protection on all POSTs.)