### PR TITLE
Add RPC tracing via appstats

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -9,13 +9,14 @@ handlers:
   static_dir: caravel/static
   secure: always
 - url: /_internal/.*
-  script: caravel.app
+  script: caravel.wsgi_app
   login: admin
   secure: always
 - url: /.*
-  script: caravel.app
+  script: caravel.wsgi_app
   secure: always
 
 builtins:
 - deferred: on
 - remote_api: on
+- appstats: on

--- a/caravel/__init__.py
+++ b/caravel/__init__.py
@@ -18,3 +18,7 @@ from caravel import utils
 # Import test modules iff running locally.
 if os.environ["SERVER_SOFTWARE"].startswith("Development/"):
     from caravel.testing import integration_test
+
+# Add tracing to the Flask app.
+from google.appengine.ext.appstats import recording
+wsgi_app = recording.appstats_wsgi_middleware(app)


### PR DESCRIPTION
Using this API, we can go to the following page to view the number, and type, of operations per request.

  https://add-rpc-tracing-dot-hosted-caravel.appspot.com/_ah/stats

Hopefully, this'll help fix the read ops bug from earlier.