### PR TITLE
Switch to batched datastore_v3.Next RPCs on fetch

### DIFF
--- a/caravel/storage/helpers.py
+++ b/caravel/storage/helpers.py
@@ -30,7 +30,7 @@ def fetch_shard(shard=""):
     query = entities.Listing.all(keys_only=True).order("-posting_time")
     if shard:
         query = query.filter("keywords =", shard)
-    return [k.name() for k in query]
+    return [k.name() for k in query.fetch(1000)]
 
 def run_query(query="", offset=0):
     """


### PR DESCRIPTION
Currently, we add hundreds of datastore_v3.Next Small RPCs, which throws us over the 0.05 MM ops daily limit. Changing to a batched fetch should fix this problem.