### PR TITLE
Remove ambiguous session.validated variable

### DIFF
--- a/caravel/controllers/listings.py
+++ b/caravel/controllers/listings.py
@@ -41,7 +41,7 @@ def show_listing(permalink):
         abort(404)
 
     # If the listing isn't yet published, check the ACL and update session.
-    if request.args.get("key") == listing.admin_key:
+    if request.args.get("key") == listing.admin_key and listing.admin_key:
         session["email"] = listing.seller
         if not listing.posting_time:
             listing.posting_time = time.time()
@@ -54,7 +54,7 @@ def show_listing(permalink):
     if buyer_form.validate_on_submit():
         return redirect(url_for("place_inquiry", permalink=permalink))
 
-    if session.get("email") and session.get("validated"):
+    if session.get("email"):
         buyer_form.email.data = session.get("email")
     return render_template("listing_show.html", listing=listing,
                            buyer_form=buyer_form)
@@ -70,15 +70,11 @@ def edit_listing(permalink):
         abort(403)
 
     if session.get("email"):
-        if session.get("validated"):
-            seller_form.email.data = session.get("email")
-            if seller_form.validate_on_submit():
-                """ TODO (georgeteo): If already validated email address,
-                then post edit directly"""
-                pass
-        else:
-            if seller_form.validate_on_submit():
-                return redirect(url_for("create", keyword="updated"))
+        seller_form.email.data = session["email"]
+        if seller_form.validate_on_submit():
+            """ TODO (georgeteo): If already validated email address,
+            then post edit directly"""
+            pass
 
     seller_form.title.data = listing.title
     seller_form.description = listing.body
@@ -120,7 +116,7 @@ def new_listing():
         )
 
         # Only allow the user to see the listing if they are signed in.
-        if session.get("email") and session.get("validated"):
+        if session.get("email"):
             return redirect(url_for("show_listing", permalink=listing.key_name))
         else:
             return redirect(url_for("search_listings"))

--- a/caravel/templates/header.html
+++ b/caravel/templates/header.html
@@ -17,26 +17,24 @@
     </div>
   </form>
   {% if session.get("email") %}
-    {% if session.get("validated") %}
-      <div class="btn-group user-button-container">
-        <button class="btn btn-default dropdown-toggle user-button"
-          type="button"  data-toggle="dropdown"
-          aria-haspopup="true" aria-expanded="true" >
-            {{ session.get('email') }}
-            <span class="caret"></span>
-        </button>
-        <ul class="dropdown-menu">
-          <li><a href="{{ url_for('new') }}">New Listing</a></li>
-          <li>
-            <form method="GET" action="/">
-                <button type="submit" class="btn btn-link btn-manage-listings" name="q" value="{{ session.get("email") }}">
-                  Manage Listings
-                </button>
-            </form>
-          </li>
-          <li><a href={{ url_for('logout') }}>Logout</a></li>
-        </ul>
-      </div>
-    {% endif %}
+    <div class="btn-group user-button-container">
+      <button class="btn btn-default dropdown-toggle user-button"
+        type="button"  data-toggle="dropdown"
+        aria-haspopup="true" aria-expanded="true" >
+          {{ session.get('email') }}
+          <span class="caret"></span>
+      </button>
+      <ul class="dropdown-menu">
+        <li><a href="{{ url_for('new') }}">New Listing</a></li>
+        <li>
+          <form method="GET" action="/">
+              <button type="submit" class="btn btn-link btn-manage-listings" name="q" value="{{ session.get("email") }}">
+                Manage Listings
+              </button>
+          </form>
+        </li>
+        <li><a href={{ url_for('logout') }}>Logout</a></li>
+      </ul>
+    </div>
   {% endif %}
 </div>


### PR DESCRIPTION
I noticed that some parts of the code were using `session["email"]` and others `session["validated"]`; if we just do `session["email"]`, our lives get somewhat easier.

This pull request also fixes the weird bug where viewing a listing puts you into that session.