### PR TITLE
Ensure that header appears inline on desktop

### DIFF
--- a/caravel/static/default.css
+++ b/caravel/static/default.css
@@ -15,40 +15,29 @@ body {
 }
 
 .branding {
-    font: 400 36px Roboto, sans-serif;
-    width: 240px;
-    margin-top: 15px;
+    font: 400 30px Roboto, sans-serif;
+    margin-top: 0.7em;
 }
 
-.logo-image{
-    height:100px;
+.logo-image {
+    height: 100px;
     display: inline;
-    margin-top:10px;
+    margin-top: 10px;
 }
 
-.search-form {
-    padding: 0 1em;
-}
-
-.user-info {
-    padding: 1em 1em;
+.user-button-container {
+    padding-top: 0.5em;
+    padding-bottom: 0.5em;
 }
 
 @media (min-width: 992px) {
     .search-form {
-        padding: 3em 0;
+        padding-top: 3em;
     }
 
-    .user-info {
-        line-height: 8em;
-        text-indent: 1em;
-        padding: 0;
+    .user-button-container {
+        padding-top: 3em;
     }
-}
-
-.user-info a {
-    color: #000;
-    text-decoration: underline;
 }
 
 /* For search results */
@@ -132,11 +121,6 @@ body {
     margin-right: 10px;
     margin-left: 10px;
 
-}
-
-.user-button-container {
-    display: inline-block;
-    margin: 42px 20px;
 }
 
 .user-button {

--- a/caravel/templates/header.html
+++ b/caravel/templates/header.html
@@ -1,11 +1,11 @@
 <div class="masthead row">
-  <div class="col-md-1">
+  <div class="col-xs-3 col-md-1">
     <img src="/static/logo.jpg" class="logo-image">
   </div>
-  <h1 class="branding col-md-2">
+  <h1 class="branding col-xs-9 col-md-2">
     <a href="/">UChicago Marketplace</a>
   </h1>
-  <form class="search-form col-md-6" method="GET" action="/">
+  <form class="search-form col-xs-12 col-md-6" method="GET" action="/">
     <div class="input-group">
       <input type="text" class="form-control" name="q"
         value="{{ request.args['q'] }}" placeholder="Search for listings..."/>
@@ -17,7 +17,7 @@
     </div>
   </form>
   {% if session["email"] %}
-    <div class="btn-group user-button-container">
+    <div class="user-button-container col-xs-12 col-md-3">
       <button class="btn btn-default dropdown-toggle user-button"
         type="button"  data-toggle="dropdown"
         aria-haspopup="true" aria-expanded="true" >


### PR DESCRIPTION
I think I broke something in a merge conflict somewhere. I also swizzled things a bit so that the logo appears next to the title on mobile, but I'm not opinionated one way or another. Oh, and I also removed some old CSS that was adding underlines to the user menu.

Before:
<img width="1155" alt="screen shot 2015-09-28 at 9 41 15 pm" src="https://cloud.githubusercontent.com/assets/14364/10154172/d39a6d4e-6629-11e5-92f9-c18271ab694f.png">
<img width="299" alt="screen shot 2015-09-28 at 9 41 06 pm" src="https://cloud.githubusercontent.com/assets/14364/10154173/d39ab4ca-6629-11e5-945e-73dd67074c1b.png">
 
After:
<img width="299" alt="screen shot 2015-09-28 at 9 40 58 pm" src="https://cloud.githubusercontent.com/assets/14364/10154176/dd0ea48a-6629-11e5-994f-23e2cfde2686.png">
<img width="1163" alt="screen shot 2015-09-28 at 9 40 43 pm" src="https://cloud.githubusercontent.com/assets/14364/10154177/dd0ef246-6629-11e5-8cf1-1de7c11365a1.png">
