### PR TITLE
Cache inflected words from entity

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -9,14 +9,13 @@ handlers:
   static_dir: caravel/static
   secure: always
 - url: /_internal/.*
-  script: caravel.wsgi_app
+  script: caravel.app
   login: admin
   secure: always
 - url: /.*
-  script: caravel.wsgi_app
+  script: caravel.app
   secure: always
 
 builtins:
 - deferred: on
 - remote_api: on
-- appstats: on

--- a/caravel/__init__.py
+++ b/caravel/__init__.py
@@ -18,7 +18,3 @@ from caravel import utils
 # Import test modules iff running locally.
 if os.environ["SERVER_SOFTWARE"].startswith("Development/"):
     from caravel.testing import integration_test
-
-# Add tracing to the Flask app.
-from google.appengine.ext.appstats import recording
-wsgi_app = recording.appstats_wsgi_middleware(app)

--- a/caravel/controllers/listings.py
+++ b/caravel/controllers/listings.py
@@ -26,7 +26,7 @@ def search_listings():
 
     # Compute the results matching that query.
     listings = helpers.run_query(query)
-    listings = itertools.islice(listings, offset, offset + 24)
+    listings = list(itertools.islice(listings, offset, offset + 24))
 
     # Render a chrome-less template for AJAH continuation.
     template = ("" if "continuation" not in request.args else "_continuation")

--- a/caravel/storage/entities.py
+++ b/caravel/storage/entities.py
@@ -21,12 +21,15 @@ class DerivedProperty(db.Property):
 
     def __get__(self, model_instance, model_class):
         """Override when this property is read from an entity."""
-        if model_instance is None:
-            return self
-        return self.derive_func(model_instance)
 
-    def __set__(self, model_instance, value):
-        """Ignore assignment to entity.prop."""
+        try:
+            result = getattr(model_instance, self._attr_name())
+            if result is not None:
+                return result
+        except AttributeError:
+            pass
+
+        return self.derive_func(model_instance)
 
 class Versioned(db.Expando):
     version = db.IntegerProperty(default=1)


### PR DESCRIPTION
(Branch name is a bit of a misnomer.)

Before, we'd spend about 3s on every request recomputing the singularized forms of each word in every entity; this patch makes it better. Next — parallel RPCs!