### PR TITLE
Add tracking for interested buyers

### DIFF
--- a/caravel/controllers/listings.py
+++ b/caravel/controllers/listings.py
@@ -65,6 +65,9 @@ def show_listing(permalink):
         buyer = buyer_form.buyer.data
         message = buyer_form.message.data
 
+        # Track what requests are sent to which people.
+        helpers.add_inqury(listing, buyer, message)
+
         mail.send_mail(
             "Marketplace <magicmonkeys@hosted-caravel.appspotmail.com>",
             listing.seller,

--- a/caravel/storage/entities.py
+++ b/caravel/storage/entities.py
@@ -100,6 +100,7 @@ class Listing(Versioned):
     posting_time = db.FloatProperty(default=0) # set to 0 iff not yet published
     categories = db.StringListProperty() # stored as keys of CATEGORIES
     admin_key = db.StringProperty(default="") # how to administer this listing
+    buyers = db.StringListProperty() # how many people are interested
 
     photos_ = db.StringListProperty(indexed=False, name="photos")
     thumbnails_ = db.StringListProperty(indexed=False, name="thumbnails")

--- a/caravel/storage/helpers.py
+++ b/caravel/storage/helpers.py
@@ -73,3 +73,19 @@ def run_query(query="", offset=0):
     merged = heapq.merge(*[_load(shard) for shard in shards])
     for _, listing in merged:
         yield listing
+
+def add_inqury(listing, buyer, message):
+    """
+    Tracks when a given buyer displays interest in the given listing.
+    """
+
+    key = listing.key()
+
+    @db.run_in_transaction
+    def txn():
+        listing = entities.Listing.get(key)
+        if buyer not in listing.buyers:
+            listing.buyers.append(buyer)
+        listing.put()
+
+    invalidate_listing(listing)

--- a/caravel/templates/listings/fullpage.html
+++ b/caravel/templates/listings/fullpage.html
@@ -47,6 +47,19 @@
           <h3 class="panel-title">Contact Seller</h3>
         </div>
         <div class="panel-body">
+        {% if session["email"] in listing.buyers %}
+          <p class="alert alert-success">
+            You have successfully expressed interest in this listing.</p>
+        {% else %}
+          {% if listing.buyers %}
+          <p class="alert alert-info">
+            {% if listing.buyers|length != 1 %}
+              This listing has {{ listing.buyers|length }} inquries.
+            {% else %}
+              This listing has 1 inqury.
+            {% endif %}
+          </p>
+          {% endif %}
           {{ wtf.quick_form(buyer_form) }}
           <p>
           <form method="post"
@@ -56,6 +69,7 @@
             <input type="submit" class="btn btn-default" value="This is mine"/>
           </form>
           </p>
+        {% endif %}
         </div>
       </div>
     {% endif %}


### PR DESCRIPTION
Fairly simple- so that we can show how much interest there is in each listing.

Test URL: https://add-buyer-tracking-dot-hosted-caravel.appspot.com/