### PR TITLE
Ensure that people don't forge emails.

### DIFF
--- a/caravel/controllers/listings.py
+++ b/caravel/controllers/listings.py
@@ -227,7 +227,7 @@ def new_listing():
                       key=listing.admin_key, _external=True)
 
         # Only allow the user to see the listing if they are signed in.
-        if session.get("email"):
+        if session.get("email") == listing.email:
             flash("Your listing has been published.")
             return redirect(url_for("show_listing",
                      permalink=listing.permalink))


### PR DESCRIPTION
Currently, if signed in, people can post listings as other people.