### PR TITLE
Add debug output to listing view

### DIFF
--- a/caravel/controllers/listings.py
+++ b/caravel/controllers/listings.py
@@ -5,7 +5,7 @@ Listings are placed by sellers when they want to sell things.
 import uuid, time
 
 from flask import render_template, request, abort, redirect, url_for, session
-from flask import flash
+from flask import flash, g
 import itertools
 
 import sendgrid
@@ -14,10 +14,18 @@ from caravel import app, policy
 from caravel.storage import helpers, entities, config
 from caravel.controllers import forms
 
+from google.appengine.api import users
+
 @app.after_request
 def show_disclaimer(response):
     session["seen_disclaimer"] = True
     return response
+
+@app.before_request
+def expose_admin_status():
+    g.is_admin = users.is_current_user_admin()
+    if "external" in request.args:
+        g.is_admin = False
 
 @app.route("/")
 def search_listings():

--- a/caravel/templates/listings/fullpage.html
+++ b/caravel/templates/listings/fullpage.html
@@ -18,6 +18,15 @@
       <div class="col-md-9">
     {% endif %}
       <h2>{{ listing.title }}</h2>
+      {% if g.is_admin %}
+      <p class="alert alert-info">
+        <strong>Debug Infromation:</strong>
+          (hide with ?external; only for admins)<br/>
+        {%- for key, value in listing.properties().items()|sort -%}
+          {{ key }}: <code>{{ listing[key] }}</code><br/>
+        {%- endfor -%}
+      </p>
+      {% endif %}
       <p>
         {% for category in listing.categories %}
           <span class="label label-default">{{ category }}</span>


### PR DESCRIPTION
Fairly rudimentary. I was using this on master... and it feels useful enough to keep long term. Thoughts? Are there other things that might be good to know?

By the way- it uses the existing App Engine users API — so as long as you're signed into Gmail with your App Engine admin account, it should show up. You can disable it for demos by adding ?external.

Test instance: er, prod hotfix, so master, but also https://add-handy-debug-view-dot-hosted-caravel.appspot.com.

Incidentally, all these test versions keep burning CPU time. It might be wise to create a separate App ID just for them...