### PR TITLE
Show remote IP address when sending messages

### DIFF
--- a/caravel/templates/email/inquiry.html
+++ b/caravel/templates/email/inquiry.html
@@ -31,7 +31,7 @@
                       background-color: #f8f8f8;">
           <tr>
             <td style="padding: 1em;write-space:pre;">
-              Buyer: {{ buyer }}<br/>
+              Buyer: {{ buyer }} (IP: {{ request.remote_addr }})<br/>
               <br/>{{ message }}</td>
           </tr>
         </table>

--- a/caravel/templates/email/inquiry.txt
+++ b/caravel/templates/email/inquiry.txt
@@ -2,7 +2,7 @@ Hello again!
 
 We've received a new inquiry for LISTINGNAME:
 
-  Buyer: {{ buyer }}
+  Buyer: {{ buyer }} (IP: {{ request.remote_addr }})
   
   {{ message.replace("\n", "\n  ") }}
 

--- a/caravel/templates/email/welcome.html
+++ b/caravel/templates/email/welcome.html
@@ -42,6 +42,8 @@
           once</strong> for your listing to be viewable by others &mdash; this
           is to protect against spam.<br/>
           If you didn't create this listing, you can safely ignore this email.
+          <br/>It was created by {{ request.remote_addr }}; please contact us if
+          anything seems strange.<br/>
           <br/><br/>
           Cheers,<br/>
           The Marketplace Team

--- a/caravel/templates/email/welcome.txt
+++ b/caravel/templates/email/welcome.txt
@@ -8,7 +8,9 @@ Your listing has been created. Please click the link below to edit it.
 Important: you'll need to click this link at least once for your listing to
 be viewable by others -- this is to protect against spam.
 
-If you didn't create this listing, you can safely ignore this email.
+If you didn't create this listing, you can safely ignore this email. It was
+created by {{ request.remote_addr }}; please contact us if anything seems
+strange.
 
 Cheers,
 The Marketplace Team


### PR DESCRIPTION
It may help us when tracking abuse users. There are legitimate privacy concerns however.

Thoughts? The first case is only for people who are placing inquiries, and the second is when they're about to place a listing. In both cases we already know their email (and hence name), as well as their affiliation with this university.

Test URL: https://show-remote-ip-dot-hosted-caravel.appspot.com