### PR TITLE
Ensure that all requests are secure by default.

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -7,11 +7,14 @@ threadsafe: yes
 handlers:
 - url: /static
   static_dir: caravel/static
+  secure: always
 - url: /_internal/.*
   script: caravel.app
   login: admin
+  secure: always
 - url: /.*
   script: caravel.app
+  secure: always
 
 builtins:
 - deferred: on


### PR DESCRIPTION
ITS has approved our TLS certificate, so I figure we might as well enable it.