### PR TITLE
Move test instances to separate app

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,9 +9,16 @@ test:
     - PATH=$PATH:~/google_appengine ./smoke_test.py
 
 deployment:
-  appengine:
-    branch: /.*/
+  development:
+    branch: /^(?!master)$/
     commands:
       - rm -Rf venv/
-      - ~/google_appengine/appcfg.py update . --version=$(git rev-parse --abbrev-ref HEAD) --oauth2_refresh_token=$OAUTH2_REFRESH_TOKEN
+      - ~/google_appengine/appcfg.py update . -A caravel-code-reviews --version=$(git rev-parse --abbrev-ref HEAD) --oauth2_refresh_token=$OAUTH2_REFRESH_TOKEN
+      - curl https://$(git rev-parse --abbrev-ref HEAD)-dot-hosted-caravel.appspot.com >/dev/null
+  
+  production:
+    branch: /^master$/
+    commands:
+      - rm -Rf venv/
+      - ~/google_appengine/appcfg.py update . --version=master --oauth2_refresh_token=$OAUTH2_REFRESH_TOKEN
       - curl https://$(git rev-parse --abbrev-ref HEAD)-dot-hosted-caravel.appspot.com >/dev/null


### PR DESCRIPTION
Right now these test instances use CPU, which is just pushing us over the limit. If we can separate it out, I suspect our CPU costs will go down.