### PR TITLE
Actually remove auto-created venv symlink

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -12,11 +12,11 @@ deployment:
   development:
     branch: /.*/
     commands:
-      - rm -Rf venv/
+      - rm venv
       - ~/google_appengine/appcfg.py update . -A caravel-code-reviews --version=$(git rev-parse --abbrev-ref HEAD) --oauth2_refresh_token=$OAUTH2_REFRESH_TOKEN
 
   production:
     branch: /^master$/
     commands:
-      - rm -Rf venv/
+      - rm venv
       - ~/google_appengine/appcfg.py update . --version=master --oauth2_refresh_token=$OAUTH2_REFRESH_TOKEN


### PR DESCRIPTION
Right now we're uploading ./venv, which contains many, many files, on each push. This will hopefully speed things up a bit.