### PR TITLE
Formalize Test Expectations

### DIFF
--- a/caravel/controllers/api.py
+++ b/caravel/controllers/api.py
@@ -54,7 +54,7 @@ def api_all_listings():
     if offset < 0:
         offset = 0
 
-    limit = int(request.args.get("offset", "100"))
+    limit = int(request.args.get("limit", "100"))
     if limit < 0:
         limit = 0
     if limit > 100:
@@ -71,7 +71,7 @@ def api_all_listings():
     externalized = [_externalize(listing) for listing in listings]
 
     pages = {}
-    if len(listings) == 50:
+    if len(listings) == limit:
         pages["nextURL"] = url_for("api_all_listings",
             offset=offset + limit, _external=True)
     if offset != 0:

--- a/caravel/controllers/listings.py
+++ b/caravel/controllers/listings.py
@@ -14,6 +14,8 @@ from caravel import app, policy
 from caravel.storage import helpers, entities
 from caravel.controllers import forms
 
+from wtforms.validators import ValidationError
+
 @app.after_request
 def show_disclaimer(response):
     session["seen_disclaimer"] = True
@@ -82,6 +84,10 @@ def show_listing(permalink):
 
         # Track what requests are sent to which people.
         helpers.add_inqury(listing, buyer, message)
+
+        # Provide a flash message.
+        flash("Your inquiry has been sent.")
+
         return redirect(url_for("show_listing", permalink=permalink))
 
     # Have the form email default to the value from the session.
@@ -103,7 +109,7 @@ def claim_listing(permalink):
 
     # Follow policy when sending an email to the user.
     try:
-        policy.claim_listing(permalink)
+        policy.claim_listing(listing)
     except ValidationError, e:
         flash(str(e), "error")
     else:

--- a/caravel/tests/helper.py
+++ b/caravel/tests/helper.py
@@ -1,0 +1,92 @@
+import unittest
+import time
+import re
+import uuid
+
+from google.appengine.ext import db
+from google.appengine.api import memcache
+
+from caravel import app
+from caravel.storage import config, entities
+
+class CaravelTestCase(unittest.TestCase):
+    def setUp(self):
+        # FIXME: Remove once everything else is TestCase-ified.
+        db.delete(db.Query(keys_only=True))
+        memcache.flush_all()
+
+        # Configure a basic HTTP client.
+        self.http_client = app.test_client()
+
+        # Capture outgoing email messages.
+        self.emails = []
+        sendgrid = config.send_grid_client
+        self._send, sendgrid.send = sendgrid.send, self.emails.append
+
+        # Ensure that UUIDs are deterministic.
+        self._uuid4 = uuid.uuid4
+        uuid.uuid4 = lambda: "ZZ-ZZ-ZZ"
+
+        # Create simple entities to play with.
+        self.listing_a = entities.Listing(
+            title="Listing tA",
+            body="Body of bA",
+            posting_time=time.time() - 4 * 3600,
+            seller="seller-a@uchicago.edu",
+            price=310,
+            categories=["category:cars"],
+            admin_key="a_key",
+            key_name="listing_a")
+        self.listing_a.put()
+
+        self.listing_b = entities.Listing(
+            title="Listing tB",
+            body="Body of bB",
+            posting_time=time.time() - 24 * 3600,
+            seller="seller-b@uchicago.edu",
+            price=7110,
+            categories=["category:apartments"],
+            key_name="listing_b")
+        self.listing_b.put()
+        
+        self.listing_c = entities.Listing(
+            title="Listing tC",
+            body="Body of bC",
+            posting_time=0.,
+            seller="seller-c@uchicago.edu",
+            price=9105,
+            categories=["category:appliances"],
+            admin_key="adminkey",
+            key_name="listing_c")
+        self.listing_c.put()
+
+        # Allow very large diffs.
+        self.maxDiff = None
+
+    def tearDown(self):
+        # Clear database.
+        db.delete(db.Query(keys_only=True))
+        memcache.flush_all()
+
+        # Un-stub uuid generation features.
+        uuid.uuid4 = self._uuid4
+        config.send_grid_client.send = self._send
+
+    # Test helper functions.
+    def clean(self, markup):
+        markup = re.sub(r'<script.*/script>', ' ', markup, flags=re.DOTALL)
+        markup = re.sub(r'<!--.*-->', '', markup, flags=re.DOTALL)
+        markup = re.sub(r'<[^>]+>', ' ', markup)
+        markup = re.sub(r'[ \t\r\n]+', ' ', markup)
+        markup = re.sub(r'Marketplace is.*lists.uchicago.edu\. ', '', markup)
+        markup = re.sub(r'(^.*UChicago Marketplace)|(&#169;.*$)', '', markup)
+        return markup.strip()
+
+    def csrf_token(self, url):
+        return re.search(r'csrf_token".*"(.*)"', self.get(url).data).group(1)
+
+    def get(self, *vargs, **kwargs):
+        return self.http_client.get(*vargs, **kwargs)
+
+    def post(self, *vargs, **kwargs):
+        return self.http_client.post(*vargs, **kwargs)

--- a/caravel/tests/test_api.py
+++ b/caravel/tests/test_api.py
@@ -1,0 +1,77 @@
+import json
+
+from caravel.storage import entities, config
+from caravel.tests import helper
+
+class TestListings(helper.CaravelTestCase):
+    def test_read_api(self):
+        cars = {
+            u"URL":
+            u"http://localhost/api/v1/listings.json?q=category%3Acars",
+            u"name": u"category:cars"
+        }
+    
+        apartments = {
+            u"URL":
+            u"http://localhost/api/v1/listings.json?q=category%3Aapartments",
+            u"name": u"category:apartments"
+        }
+
+        listing_a = {
+            u"body": u"Body of bA",
+            u"categories": [cars],
+            u"photos": [],
+            u"htmlURL": u"http://localhost/listing_a",
+            u"inquiries": 0,
+            u"jsonURL": u"http://localhost/api/v1/listing_a.json",
+            u"postingTime": self.listing_a.posting_time,
+            u"price": 3.1,
+            u"title": u"Listing tA"
+        }
+
+        listing_b = {
+            u"body": u"Body of bB",
+            u"categories": [apartments],
+            u"photos": [],
+            u"htmlURL": u"http://localhost/listing_b",
+            u"inquiries": 0,
+            u"jsonURL": u"http://localhost/api/v1/listing_b.json",
+            u"postingTime": self.listing_b.posting_time,
+            u"price": 71.1,
+            u"title": u"Listing tB"
+        }
+
+        # Try to retreive all listings.
+        self.assertEquals(
+            json.loads(self.get("/api/v1/listings.json").data),
+            {
+                u"limit": 100,
+                u"offset": 0,
+                u"listings": [listing_a, listing_b],
+            }
+        )
+
+        self.assertEquals(
+            json.loads(self.get("/api/v1/listings.json?offset=1").data),
+            {
+                u"limit": 100,
+                u"offset": 1,
+                u"listings": [listing_b],
+                u"previousURL":
+                    u"http://localhost/api/v1/listings.json?offset=0"
+            }
+        )
+
+        self.assertEquals(
+            json.loads(self.get("/api/v1/listings.json?limit=1").data),
+            {
+                u"limit": 1,
+                u"offset": 0,
+                u"listings": [listing_a],
+                u"nextURL": u"http://localhost/api/v1/listings.json?offset=1"
+            }
+        )
+
+        # Check that one listing appears is as it should be.
+        self.assertEquals(
+            json.loads(self.get("/api/v1/listing_a.json").data), listing_a)


### PR DESCRIPTION
The `"foo" in page.data` pattern felt a little hokey, so here's a new version that is a bit more complete. It accounts for coverage slightly differently, but in general:

```
Name                                        Stmts   Miss  Cover
---------------------------------------------------------------
caravel/__init__.py                            15     15     0%
caravel/controllers/__init__.py                 0      0   100%
caravel/controllers/api.py                     35     16    54%
caravel/controllers/forms.py                   50     43    14%
caravel/controllers/listings.py               168     78    54%
caravel/daemons/__init__.py                     0      0   100%
caravel/daemons/delete_old_photos.py            5      5     0%
caravel/daemons/migration.py                   10     10     0%
caravel/daemons/replication.py                 36     36     0%
caravel/policy.py                              12      6    50%
caravel/storage/__init__.py                     0      0   100%
caravel/storage/cache.py                       70     17    76%
caravel/storage/config.py                      13     13     0%
caravel/storage/dos.py                         12      5    58%
caravel/storage/entities.py                    99     63    36%
caravel/storage/helpers.py                     54     11    80%
caravel/storage/photos.py                      58     58     0%
caravel/tests/__init__.py                       0      0   100%
caravel/tests/helper.py                        44     15    66%
caravel/tests/test_api.py                      13      5    62%
caravel/tests/test_cache.py                    36      7    81%
caravel/tests/test_dos.py                      15      4    73%
caravel/tests/test_entities.py                 12      3    75%
caravel/tests/test_helpers.py                  27      4    85%
caravel/tests/test_listings.py                 38      9    76%
caravel/utils.py                               27     10    63%
---------------------------------------------------------------
TOTAL                                         849    433    49%
```

As a bonus, this also found a bug in the API and a missing flash in the "claim listing" flow.