### PR TITLE
Add App Engine users to authenticate to Marketplace

### DIFF
--- a/caravel/controllers/custom_fields.py
+++ b/caravel/controllers/custom_fields.py
@@ -1,0 +1,45 @@
+import wtforms
+from markupsafe import Markup
+from google.appengine.api import users
+from flask import request
+
+class PrincipalField(wtforms.StringField):
+    """
+    A PrincipalField is one that represents an email address.
+    """
+
+    def process_formdata(self, value):
+        """
+        Overrides the value sent in the form if asked.
+        """
+
+        user = users.get_current_user()
+        if user:
+            value = [user.email()]
+        return super(PrincipalField, self).process_formdata(value)
+
+    def __call__(self, **kwargs):
+        """
+        Renders a control with a Sign In button.
+        """
+
+        kwargs["class"] = kwargs.get("class", "") + " inline-user-control"
+        kwargs["placeholder"] = "enter email..."
+
+        if users.get_current_user():
+            return Markup(
+                "<p class='form-control-static'><strong>{}</strong> "
+                "or <a href='{}' class='btn btn-success'>Sign out</a></p>"
+            ).format(
+                users.get_current_user().email(),
+                users.create_logout_url(request.url),
+            )
+
+        else:
+            return Markup(
+                "<div><a href='{}' class='btn btn-success'>Sign in with "
+                "CNetID</a>or {}</div>"
+            ).format(
+                users.create_login_url(request.url),
+                super(PrincipalField, self).__call__(**kwargs),
+            )

--- a/caravel/controllers/forms.py
+++ b/caravel/controllers/forms.py
@@ -11,6 +11,7 @@ import logging
 
 from caravel import policy, app
 from caravel.storage import entities
+from caravel.controllers import custom_fields
 
 class CheckboxesField(SelectMultipleField):
     option_widget = CheckboxInput()
@@ -80,8 +81,8 @@ class ValidatedForm(Form):
         return result
 
 class BuyerForm(ValidatedForm):
-    buyer = StringField("Email", description="UChicago Email Preferred",
-                validators=[Email()])
+    buyer = custom_fields.PrincipalField("Email",
+                validators=[DataRequired(), Email()])
     message = TextAreaField("Message")
     captcha = RecaptchaField()
     submit = SubmitField("Send")
@@ -102,7 +103,7 @@ class EditListingForm(ValidatedForm):
     submit = SubmitField("Post")
 
 class NewListingForm(EditListingForm):
-    seller = StringField("Email", description="UChicago Email Required",
-                                  validators=[Email()])
+    seller = custom_fields.PrincipalField("Email",
+                                  validators=[DataRequired(), Email()])
 
 CsrfProtect(app)

--- a/caravel/static/default.css
+++ b/caravel/static/default.css
@@ -103,6 +103,11 @@ form .thumbnail {
     max-width: 200px;
 }
 
+.form-control.inline-user-control {
+	display: inline-block;
+	width: auto;
+}
+
 /* Footer */
 .copyright {
     margin-top: 15px;

--- a/caravel/tests/test_listings.py
+++ b/caravel/tests/test_listings.py
@@ -42,7 +42,7 @@ class TestListings(helper.CaravelTestCase):
         self.assertEqual(self.clean(self.get("/listing_b").data),
             "New Listing Your inquiry has been sent. Listing \xe2\x98\x86B "
             "Apartments $71.10 Body of \xe2\x98\x86B Contact Seller This "
-            "listing has 1 inqury. Email UChicago Email Preferred Message")
+            "listing has 1 inqury. Email Sign in with CNetID or Message")
 
         # Verify that the proper email was sent.
         self.assertEqual(self.emails[0].to[0], "seller-b@uchicago.edu")
@@ -176,7 +176,7 @@ class TestListings(helper.CaravelTestCase):
         self.assertEqual(self.clean(self.get("/listing_a").data),
             "New Listing We&#39;ve emailed you a link to edit this listing. "
             "Listing \xe2\x98\x86A Cars $3.10 Body of \xe2\x98\x86A Contact "
-            "Seller Email UChicago Email Preferred Message")
+            "Seller Email Sign in with CNetID or Message")
 
         # Ensure that the message is as we expect.
         self.assertEqual(self.emails[0].to[0], "seller-a@uchicago.edu")


### PR DESCRIPTION
The lazy person's path to Shibboleth logins. Right now there's no additional verification — but once we add moderation that can feed into the verification level of each email.