### PR TITLE
Avoid spamming users on schema updates

### DIFF
--- a/caravel/model/listing.py
+++ b/caravel/model/listing.py
@@ -3,7 +3,7 @@ from caravel.utils import Principal, Device
 from caravel.model.moderation import ModeratedMixin
 from caravel.model.temporal import TimeOrderMixin
 from caravel.model.categories import CategoriesMixin
-from caravel.model.attachments import PhotosMixin
+from caravel.model.attachments import PhotosMixin, Photo
 from caravel.model.migration import SchemaMixin
 from caravel.model.priced import PriceMixin
 from caravel.model.principal import PrincipalMixin
@@ -62,4 +62,6 @@ def to_ndb_schema(listing):
     listing.categories = [re.sub(r'^category:', '', x) for x in
                              listing.categories]
 
-    # listing.photos = [Photo(x) for x in listing.photos_]
+    listing.photos = [
+        Photo(re.sub(r'-large$', '', p.path)) for p in listing.photos]
+    listing.run_trigger = True

--- a/caravel/tests/test_migration.py
+++ b/caravel/tests/test_migration.py
@@ -72,6 +72,8 @@ class TestListings(helper.CaravelTestCase):
         listing = Listing.get_by_key_name("my-listing-name")
         self.assertEquals(listing.version, 11)
 
+        # Verify that no emails were sent.
+        self.assertEquals(self.emails, [])
 
     def test_migrate_from_super_old(self):
 
@@ -100,3 +102,5 @@ class TestListings(helper.CaravelTestCase):
         self.assertEquals(listing.body, u"Body of Legacy \xe2\x98\x86")
         self.assertEquals(listing.categories, ["miscellaneous"])
 
+        # Verify that no emails were sent.
+        self.assertEquals(self.emails, [])


### PR DESCRIPTION
Fairly rudimentary. This should prevent the spam we were getting earlier (plus fix the missing photos that are showing up on the test instance).