### PR TITLE
Block requests from Tor to Marketplace

### DIFF
--- a/caravel/templates/header.html
+++ b/caravel/templates/header.html
@@ -46,8 +46,10 @@
       </div>
     </form>
     <div class="user-button-container">
+      {% if not is_from_tor() %}
       <a href="{{ url_for('new_listing') }}" class="btn btn-default btn-user">
         New Listing</a>
+      {% endif %}
       <div class="btn-group btn-user">
         <a href="{{ url_for('search_listings', q=request.args.q,
                       v='th') }}"

--- a/caravel/templates/listings/fullpage.html
+++ b/caravel/templates/listings/fullpage.html
@@ -34,6 +34,7 @@
       </p>
       <p style="white-space:pre-wrap">{{ listing.body }}</p>
     </div>
+    {% if not is_from_tor() %}
     <div class="col-md-3">
     {% if current_user and listing.principal.email == current_user.email() %}
       <div class="panel panel-default">
@@ -84,6 +85,7 @@
         {% endif %}
         </div>
       </div>
+    {% endif %}
     {% endif %}
   </div>
 </div>

--- a/caravel/utils/__init__.py
+++ b/caravel/utils/__init__.py
@@ -1,2 +1,3 @@
 from caravel.utils.principals import Principal, Device
 from caravel.utils.emails import send_mail
+from caravel.utils.tor import TorDetector

--- a/caravel/utils/tor.py
+++ b/caravel/utils/tor.py
@@ -1,0 +1,37 @@
+import threading
+import time
+import urllib
+import re
+
+EXIT_NODES_URL = "https://check.torproject.org/exit-addresses"
+
+class TorDetector(object):
+    def __init__(self):
+        """
+        Initializes this Tor detector object.
+        """
+
+        self.lock = threading.Lock()
+        self.exit_nodes = []
+        self.last_update = None
+
+    def _update(self):
+        """
+        Updates the list of Tor exit nodes from the Tor project.
+        """
+
+        if not self.last_update or (time.time() - self.last_update) > 3600:
+            data = urllib.urlopen(EXIT_NODES_URL).read()
+            matches = re.finditer(r'ExitAddress ([^ ]+)', data)
+
+            self.exit_nodes = set([x.group(1) for x in matches])
+            self.last_update = time.time()
+
+    def is_tor_exit_node(self, ip_address):
+        """
+        Returns True if the given IP address is a Tor exit node.
+        """
+
+        with self.lock:
+            self._update()
+            return ip_address in self.exit_nodes

--- a/index.yaml
+++ b/index.yaml
@@ -15,4 +15,3 @@ indexes:
   - name: keywords
   - name: posted_at
     direction: desc
-


### PR DESCRIPTION
Fairly rudimentary. We have a local cache, expiring every hour, that downloads the full list of exit nodes from https://check.torproject.org/exit-addresses. Using that list, we block new listings, edits, and inquiries.