### PR TITLE
Reduce background writes

### DIFF
--- a/caravel/__init__.py
+++ b/caravel/__init__.py
@@ -31,9 +31,6 @@ from flask_wtf.csrf import CsrfProtect
 CsrfProtect(app)
 
 # Imported for side effects:
-import caravel.model
-import caravel.utils
-import caravel.storage.config
 import caravel.controllers.listings
 import caravel.controllers.api
 import caravel.controllers.moderation

--- a/caravel/daemons/migration.py
+++ b/caravel/daemons/migration.py
@@ -2,13 +2,24 @@
 The migration daemon pulls the latest listings from the old site.
 """
 
+from google.appengine.ext import ndb
 from caravel import app, model
+import itertools
+
+
+def grouper(iterable, n, fillvalue=None):
+    "Collect data into fixed-length chunks or blocks"
+    # grouper('ABCDEFG', 3, 'x') --> ABC DEF Gxx
+    args = [iter(iterable)] * n
+    return itertools.izip_longest(fillvalue=fillvalue, *args)
+
 
 @app.route("/_internal/migrate_schema")
 def migrate_schema():
     q = model.Listing.query(
         model.Listing.version < model.Listing.SCHEMA_VERSION)
 
-    q.map(lambda listing: listing.put(), limit=100)
+    for entities in grouper(itertools.islice(q, 0, 1000), 100):
+        ndb.put_multi([entity for entity in entities if entity])
 
     return "ok"

--- a/caravel/utils/emails.py
+++ b/caravel/utils/emails.py
@@ -5,8 +5,6 @@ Allows easy access to an SMTP server.
 import sendgrid
 import logging
 
-from caravel.utils import principals
-
 SENDER = "Marketplace Team <marketplace@lists.uchicago.edu>"
 
 
@@ -14,6 +12,8 @@ def send_mail(to, subject, html, text, reply_to=None, sender=SENDER):
     """
     Sends an email to the given principals.
     """
+
+    from caravel.utils import principals
 
     # Verify that we are not sending spam to people.
     if not (isinstance(to, principals.Principal) and to.valid):

--- a/cron.yaml
+++ b/cron.yaml
@@ -4,7 +4,7 @@ cron:
   schedule: every 24 hours
 - description: migrate database schema
   url: /_internal/migrate_schema
-  schedule: every 10 minutes
+  schedule: every 20 minutes
 - description: nag moderators
   url: /_internal/nag_moderators
   schedule: every day 09:00


### PR DESCRIPTION
Primarily, this change spreads the cache invalidations out a bit, reducing the total number of index writes — but the bigger change was just finishing the "update schema" MapReduce.