### PR TITLE
Prevent OoM on home page load

### DIFF
--- a/caravel/controllers/listings.py
+++ b/caravel/controllers/listings.py
@@ -16,6 +16,7 @@ from google.appengine.api import users
 import uuid
 import datetime
 import math
+import itertools
 
 TOR_DETECTOR = utils.TorDetector()
 
@@ -129,13 +130,15 @@ def search_listings():
     limit = 24
 
     # Compute the results matching that query.
-    listings = list(model.Listing.matching(query))[offset:offset + limit]
+    listings = list(itertools.islice(model.Listing.matching(query), offset,
+                                     offset + limit))
 
     # Render a chrome-less template for AJAH continuation.
     template = ("" if "continuation" not in request.args else "_continuation")
 
     return render_template("index{}.html".format(template),
-        listings=listings, view=view, query=query)
+                           listings=listings, view=view, query=query)
+
 
 @app.route("/<listing:listing>", methods=["GET", "POST"])
 def show_listing(listing):

--- a/caravel/model/full_text.py
+++ b/caravel/model/full_text.py
@@ -1,12 +1,20 @@
 from google.appengine.ext import ndb
 from google.appengine.api import memcache
 import json
+import itertools
 
 FTS = "fts:"
 
 def tokenize(value):
     """Parses the given string into words."""
     return value.lower().split() + [""]
+
+
+def grouper(iterable, n, fillvalue=None):
+    "Collect data into fixed-length chunks or blocks"
+    # grouper('ABCDEFG', 3, 'x') --> ABC DEF Gxx
+    args = [iter(iterable)] * n
+    return itertools.izip_longest(fillvalue=fillvalue, *args)
 
 
 class FullTextMixin(ndb.Model):
@@ -40,9 +48,12 @@ class FullTextMixin(ndb.Model):
         memcache.set_multi(writeback, time=3600, key_prefix=FTS)
 
         # Elide potentially stale entries from the cache.
-        for candidate in ndb.get_multi([key for key in keys if key in matches]):
-            if candidate and set(words).issubset(set(candidate.keywords)):
-                yield candidate
+        keys = [key for key in keys if key in matches]
+
+        for keys in grouper(keys, n=12):
+            for entity in ndb.get_multi([key for key in keys if key]):
+                if entity and set(words).issubset(set(entity.keywords)):
+                    yield entity
 
     def _post_put_hook(self, future):
         """Clear the cache of entries maching these keywords."""


### PR DESCRIPTION
Currently, we load every listing in memory, which makes the home page really slow. This change fixes that.