### PR TITLE
Fix full text indexing

### DIFF
--- a/caravel/model/full_text.py
+++ b/caravel/model/full_text.py
@@ -4,9 +4,10 @@ import json
 
 FTS = "fts:"
 
+
 def tokenize(value):
     """Parses the given string into words."""
-    return value.lower().split() + [""]
+    return value.lower().split()
 
 
 class FullTextMixin(ndb.Model):
@@ -19,6 +20,11 @@ class FullTextMixin(ndb.Model):
 
         # Check contents of cache.
         words = tokenize(query)
+        if not words:
+            for item in klass.query().order(-klass.posted_at):
+                yield item
+            return
+
         results = memcache.get_multi(words, key_prefix=FTS)
         matches = None
         in_order = None


### PR DESCRIPTION
Currently every search needlessly requests `fts:`, which can be avoided by using another small query. (As it stands, `fts:` is cleared on every update, so we're basically already requesting it.)