### PR TITLE
Revert "remove api validation"

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -20,6 +20,10 @@ handlers:
   script: caravel.app
   login: required
   secure: always
+- url: /api/v1/.*
+  script: caravel.app
+  login: required
+  secure: always
 - url: /.*
   script: caravel.app
   secure: always


### PR DESCRIPTION
Reverts uchicago-sg/caravel#227 because it has broken the site three days in a row.