### PR TITLE
Bounce requests back to proper host.

### DIFF
--- a/caravel/controllers/listings.py
+++ b/caravel/controllers/listings.py
@@ -128,6 +128,12 @@ def show_disclaimer(response):
     return response
 
 
+@app.before_request
+def might_be_wrong_url():
+    if request.host == "hosted-caravel.appspot.com":
+        return redirect(request.url.replace(
+            "hosted-caravel.appspot.com", "marketplace.appspot.com"))
+
 @app.route("/")
 def search_listings():
     """Display a list of listings that match the given query."""


### PR DESCRIPTION
Right now, a bunch of people are getting emails that send them to hosted-caravel.appspot.com domains. This fixes that (i'm also working on the email side).