### PR TITLE
Avoid reloading keywords protobuf on each load

### DIFF
--- a/caravel/model/full_text.py
+++ b/caravel/model/full_text.py
@@ -18,8 +18,17 @@ def grouper(iterable, n, fillvalue=None):
     return itertools.izip_longest(fillvalue=fillvalue, *args)
 
 
+class AvoidRereadingFromPBProperty(ndb.ComputedProperty):
+    """
+    Since ComputedPropertys are overwritten on writes anyway, we might as well
+    avoid the expensive desearlization process for reads.
+    """
+
+    def _deserialize(self, ent, property, depth=1): pass
+
+
 class FullTextMixin(ndb.Model):
-    keywords = ndb.ComputedProperty(
+    keywords = AvoidRereadingFromPBProperty(
         lambda self: list(set(self._keywords())), repeated=True)
 
     @classmethod


### PR DESCRIPTION
It's a bit of a hack, but it seems to reduce latency to around 600ms on the home page... as well as speeding up the API. I'm going to keep poking to see if there's anything else to cut out.

Before you merge- I'm a little worried about the feature impacts of this patch. I don't think this integration is tested (because the stubs don't handle this case), and I want to make sure this works in practice. I've played with the test instance somewhat, but can you test it as well?

https://prevent-reloading-keywords-dot-caravel-code-reviews.appspot.com