### PR TITLE
Add automatic moderation

### DIFF
--- a/caravel/__init__.py
+++ b/caravel/__init__.py
@@ -17,10 +17,11 @@ if "APPLICATION_ID" not in os.environ:
     # Hide all the App Engine cruft.
     logging.disable(logging.INFO)
 
-    from google.appengine.ext import testbed
+    from google.appengine.ext import testbed, ndb
     testbed = testbed.Testbed()
     testbed.activate()
     testbed.init_all_stubs()
+    ndb.get_context().set_cache_policy(False)
     app.testing = True
 
 # Ensure that the Recaptcha field is small.

--- a/caravel/controllers/listings.py
+++ b/caravel/controllers/listings.py
@@ -134,6 +134,7 @@ def might_be_wrong_url():
         return redirect(request.url.replace(
             "hosted-caravel.appspot.com", "marketplace.appspot.com"))
 
+
 @app.route("/")
 def search_listings():
     """Display a list of listings that match the given query."""
@@ -176,6 +177,7 @@ def show_listing(listing):
 
         inquiry = model.UnapprovedInquiry(listing=listing.key)
         form.populate_obj(inquiry)
+        inquiry.posted_at = datetime.datetime.now()
         inquiry.put()
         if isinstance(inquiry, model.UnapprovedInquiry):
             flash("Your inquiry has been recorded and is awaiting moderation.")

--- a/caravel/static/default.css
+++ b/caravel/static/default.css
@@ -277,3 +277,8 @@ form .thumbnail {
 .inline-form {
     display: inline;
 }
+
+/* moderation interface */
+.hide-after-first + .hide-after-first {
+    display: none;
+}

--- a/caravel/static/js/moderation.js
+++ b/caravel/static/js/moderation.js
@@ -11,11 +11,21 @@ var enableModeration = function(csrfToken) {
         elem.addEventListener("click", function() {
             var this_ = this, xhr = new XMLHttpRequest;
             xhr.open("POST", "/moderation", true);
-            this_.parentNode.parentNode.remove();
+            var automod = document.getElementById("automod");
+            var container = this_.parentNode.parentNode.parentNode.parentNode;
+            var next = container.nextSibling.nextSibling.childNodes[5];
+            var anyMoreToModerate = !!next;
+            if (anyMoreToModerate)
+              next.appendChild(automod);
+            container.remove();
+
+            this_.parentNode.parentNode.parentNode.parentNode.remove();
             xhr.onreadystatechange = function() {
                 if (xhr.readyState == 4) {
-                    if (xhr.status <= 200 || xhr.status > 300)
-                        window.alert("XHR FAILED");
+                    if (xhr.status < 200 || xhr.status >= 300)
+                        window.alert("XHR FAILED: " + xhr.status);
+                    else if (!anyMoreToModerate)
+                        window.location.reload();
                 }
             };
             xhr.setRequestHeader("Content-type",

--- a/caravel/templates/layout.html
+++ b/caravel/templates/layout.html
@@ -1,53 +1,21 @@
-<!DOCTYPE html>
-<html>
-<head lang="en">
-  {% block head %}
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link href='https://fonts.googleapis.com/css?family=Roboto:100,300,400' rel='stylesheet' type='text/css'>
-    <link rel="stylesheet" href="/static/css/bootstrap.min.css">
-    <link rel="stylesheet" href="/static/default.css"/>
-    <script src="/static/js/jquery-plus-bootstrap.min.js" async></script>
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-    <script type="text/javascript">
-      window.addEventListener("load", function() {
-        if (window.innerWidth <= 750)
-          window.scrollTo(0,
-            document.getElementById("top-of-content").offsetTop);
-      });
-    </script>
-    <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-      ga('create', 'UA-65745513-2', 'auto');
-      ga('send', 'pageview');
-
-    </script>
-    <title> UChicago Marketplace - {% block title %} {% endblock %}</title>
-  {% endblock %}
-</head>
-<body>
-    <div class="container">
-      {% include "header.html" %}
-      {% for category, message in get_flashed_messages(with_categories=true) %}
-        <div class="alert alert-info alert-{{ category }}" role="alert">
-          {{ message }}</div>
-      {% endfor %}
-      {% if not session["seen_disclaimer"] %}
-        <div class="alert alert-warning" role="alert">
-          Marketplace is a service provided through Student Government and is
-          not moderated or maintained by the University of Chicago. Any
-          concerns about the site should be directed to
-          marketplace@lists.uchicago.edu.
-        </div>
-      {% endif %}
-      {% block content %}
-      {% endblock %}
-      {% include "footer.html" %}
-    </div>
-</body>
-</html>
+{% extends "plain_layout.html" %}
+{% block body %}
+  <div class="container">
+    {% include "header.html" %}
+    {% for category, message in get_flashed_messages(with_categories=true) %}
+      <div class="alert alert-info alert-{{ category }}" role="alert">
+        {{ message }}</div>
+    {% endfor %}
+    {% if not session["seen_disclaimer"] %}
+      <div class="alert alert-warning" role="alert">
+        Marketplace is a service provided through Student Government and is
+        not moderated or maintained by the University of Chicago. Any
+        concerns about the site should be directed to
+        marketplace@lists.uchicago.edu.
+      </div>
+    {% endif %}
+    {% block content %}
+    {% endblock %}
+    {% include "footer.html" %}
+  </div>
+{% endblock %}

--- a/caravel/templates/moderation/automod.html
+++ b/caravel/templates/moderation/automod.html
@@ -1,0 +1,36 @@
+<div class="panel panel-default" id="automod">
+  <div class="panel-heading">
+    <h3 class="panel-title">Automatic Moderation</h3>
+  </div>
+  <form class="panel-body" method="post">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+    <p class="form-group">
+      <input type="hidden" name="automod" id="automod-enabled"
+        value="{{ 'true' if config.enabled else 'false' }}"/>
+      <div class="btn-group">
+        {% if config.enabled %}
+        <button class="btn btn-success" disabled>Enable</a>
+        <button class="btn btn-default"
+           onclick="document.getElementById('automod-enabled').value = 'false';
+                    this.parentNode.parentNode.parentNode.submit();">Disable</a>
+        {% else %}
+        <button class="btn btn-default"
+           onclick="document.getElementById('automod-enabled').value = 'true';
+                    this.parentNode.parentNode.parentNode.submit();">Enable</a>
+        <button class="btn btn-danger" disabled>Disable</a>
+        {% endif %}
+      </div>
+    </p>
+    {% if config.enabled %}
+    <textarea class="form-control" name="blacklist"
+      rows="10" placeholder="blacklist (regexps)">{{ 
+          "\n".join(config.blacklist) }}</textarea>
+    <p class="form-group">
+      <label for="min-delay">Minimum Delay (m):</label>
+      <input id="min-delay" name="min_delay" type="number" class="form-control"
+        value="{{ config.min_delay }}"/>
+    </p>
+    <input type="submit" class="btn btn-success" value="Save"/>
+    {% endif %}
+  </div>
+</div>

--- a/caravel/templates/moderation/view.html
+++ b/caravel/templates/moderation/view.html
@@ -5,58 +5,77 @@
   <script src="/static/js/moderation.js"></script>
 {% endblock %}
 {% block content %}
-  <h2>Inquiries</h2>
-  <table class="table table-striped">
-    <thead>
-      <tr>
-        <th>Device</th>
-        <th>Listing</th>
-        <th>Message</th>
-        <th>Email</th>
-        <th>Moderation</th>
-      </tr>
-    </thead>
-    {% for inquiry in inquiries %}
-    <tr>
-      <td>{{ user_agent(inquiry.principal.device.user_agent) }}<br/>
-          {{ inquiry.principal.device.ip_address }}</td>
-      <td><a href="{{ url_for('show_listing',
-            listing=inquiry.listing.get()) }}">
-          {{ inquiry.listing.get().title }}</td>
-      <td>{{ inquiry.message }}</td>
-      <td>{{ inquiry.principal.email }}</td>
-      <td><a data-approve="{{ inquiry.key.urlsafe() }}"
-             class="btn btn-success">Approve</a>
-          <a data-deny="{{ inquiry.key.urlsafe() }}"
-             class="btn btn-danger">Deny</a></td>
-    </tr>
-    {% endfor %}
-  </table>
-  <h2>Listings</h2>
-  <table class="table table-striped">
-    <thead>
-      <tr>
-        <th>Device</th>
-        <th>Title</th>
-        <th>Body</th>
-        <th>Email</th>
-        <th>Moderation</th>
-      </tr>
-    </thead>
-    {% for listing in listings %}
-    <tr>
-      <td>{{ user_agent(listing.principal.device.user_agent) }}</td>
-      <td>{{ listing.principal.device.ip_address }}</td>
-      <td>{{ listing.title }}</td>
-      <td>{{ listing.body }}</td>
-      <td>{{ listing.principal.email }}</td>
-      <td><a data-approve="{{ listing.key.urlsafe() }}"
+<div class="container">
+  {% if not listings and not inquiries %}
+    <h1 style="text-align:center">All done!</h1>
+  {% endif %}
+  {% for listing in listings %}
+  <div class="row hide-after-first">
+    <div class="col-md-3">
+      {% for photo in listing.photos %}
+        <a href="{{ photo.public_url('large') }}" class="thumbnail">
+          <img src="{{ photo.public_url('large') }}"/>
+        </a>
+      {% endfor %}
+    </div>
+    <div class="col-md-6">
+      <h2>{{ listing.title }}</h2>
+      <p>
+        {% for category in listing.categories %}
+          <span class="label label-default">{{ category }}</span>
+        {% endfor %}
+      </p>
+      <p>Posted <strong>{{ listing.posted_at|as_duration }}</strong> by
+         <strong>{{ listing.principal.email }}</strong>.
+         Price: <strong>{{ '${:,.2f}'.format(listing.price) }}</strong></p>
+      <p style="white-space:pre-wrap">{{ listing.body }}</p>
+    </div>
+    <div class="col-md-3">
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          <h3 class="panel-title">Moderate Listing</h3>
+        </div>
+        <div class="panel-body">
+          <a data-approve="{{ listing.key.urlsafe() }}"
              class="btn btn-success">Approve</a>
           <a data-deny="{{ listing.key.urlsafe() }}"
-             class="btn btn-danger">Deny</a></td>
-    </tr>
-    {% endfor %}
-  </table>
+             class="btn btn-danger">Delete</a>
+        </div>
+      </div>
+      {% if loop.first %}
+        {% include "moderation/automod.html" %}
+      {% endif %}
+    </div>
+  </div>
+  {% endfor %}
+
+  {% for inquiry in inquiries %}
+  <div class="row hide-after-first">
+    <div class="col-md-9">
+      <h2>Inquiry: {{ inquiry.listing.get().title }}</h2>
+      <p>Sent <strong>{{ inquiry.posted_at|as_duration }}</strong> by
+         <strong>{{ inquiry.principal.email }}</strong>.</p>
+      <p style="white-space:pre-wrap">{{ inquiry.body }}</p>
+    </div>
+    <div class="col-md-3">
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          <h3 class="panel-title">Moderate Inquiry</h3>
+        </div>
+        <div class="panel-body">
+          <a data-approve="{{ inquiry.key.urlsafe() }}"
+             class="btn btn-success">Approve</a>
+          <a data-deny="{{ inquiry.key.urlsafe() }}"
+             class="btn btn-danger">Delete</a>
+        </div>
+      </div>
+      {% if loop.first and not listings %}
+        {% include "moderation/automod.html" %}
+      {% endif %}
+    </div>
+  </div>
+  {% endfor %}
+
   <script type="text/javascript">
     enableModeration("{{ csrf_token() }}")</script>
 {% endblock %}

--- a/caravel/templates/plain_layout.html
+++ b/caravel/templates/plain_layout.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head lang="en">
+  {% block head %}
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href='https://fonts.googleapis.com/css?family=Roboto:100,300,400' rel='stylesheet' type='text/css'>
+    <link rel="stylesheet" href="/static/css/bootstrap.min.css">
+    <link rel="stylesheet" href="/static/default.css"/>
+    <script src="/static/js/jquery-plus-bootstrap.min.js" async></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+    <script type="text/javascript">
+      window.addEventListener("load", function() {
+        if (window.innerWidth <= 750)
+          window.scrollTo(0,
+            document.getElementById("top-of-content").offsetTop);
+      });
+    </script>
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-65745513-2', 'auto');
+      ga('send', 'pageview');
+
+    </script>
+    <title> UChicago Marketplace - {% block title %} {% endblock %}</title>
+  {% endblock %}
+</head>
+<body>
+{% block body %}
+{% endblock %}
+</body>
+</html>

--- a/caravel/tests/test_automod.py
+++ b/caravel/tests/test_automod.py
@@ -1,0 +1,105 @@
+from caravel import model
+
+from caravel.tests import helper
+
+
+class TestAutomaticModeration(helper.CaravelTestCase):
+
+    def test_control_panel(self):
+        # Post a new listing.
+        self.post("/listing_b", data={
+            "principal": "buyer@foo.com",
+            "message": u"message\u2606 goes here",
+            "csrf_token": self.csrf_token("/listing_b"),
+        })
+
+        # Post an inquiry.
+        self.post("/new", data={
+            "csrf_token": self.csrf_token("/new"),
+            "title": u"Title of \u2606D",
+            "body": u"Body of \u2606D",
+            "price": "3.441",
+            "principal": "seller-d@uchicago.edu",
+            "categories": "apartments",
+            "uploaded_photos-2-image":
+                ("caravel/tests/test-pattern.gif", "t.jpg")
+        })
+
+        with self.google_apps_user("foo@uchicago.edu"):
+            self.assertLongString(self.get("/moderation").data)
+
+            # Approve the inquiry
+            self.post("/moderation", data={
+                "csrf_token": self.ajax_csrf_token("/moderation"),
+                "approve": model.UnapprovedListing.query().get().key.urlsafe(),
+            })
+
+            self.assertLongString(self.get("/moderation").data)
+
+            # Approve the listing.
+            self.post("/moderation", data={
+                "csrf_token": self.ajax_csrf_token("/moderation"),
+                "approve": model.UnapprovedInquiry.query().get().key.urlsafe(),
+            })
+
+            self.assertLongString(self.get("/moderation").data)
+
+    def test_automod(self):
+        # Post a new inqury.
+        self.post("/listing_b", data={
+            "principal": "buyer@foo.com",
+            "message": u"message\u2606 goes here",
+            "csrf_token": self.csrf_token("/listing_b"),
+        })
+
+        # Post some fraud.
+        self.post("/new", data={
+            "csrf_token": self.csrf_token("/new"),
+            "title": u"Title of \u2606D",
+            "body": u"Body of \u2606D",
+            "price": "3.441",
+            "principal": "marycole396@yahoo.com",
+            "categories": "apartments",
+            "uploaded_photos-2-image":
+                ("caravel/tests/test-pattern.gif", "t.jpg")
+        })
+
+        self.assertEquals(1, len(list(model.UnapprovedListing().query())))
+        self.assertEquals(1, len(list(model.UnapprovedInquiry().query())))
+
+        # Clear flash messages.
+        self.get("/")
+
+        with self.google_apps_user("admin@uchicago.edu"):
+            # By default, automod does nothing.
+            self.get("/_internal/automod")
+            self.assertEquals(self.emails, [])
+            self.assertLongString(self.get("/moderation").data)
+
+            # But if enabled, it approves just the inquiry.
+            self.post("/moderation", data={
+                "csrf_token": self.csrf_token("/moderation"),
+                "automod": "true"
+            })
+
+            self.post("/moderation", data={
+                "csrf_token": self.csrf_token("/moderation"),
+                "automod": "true",
+                "blacklist": "^marycole.*",
+                "min_delay": "0",
+            })
+
+            # When configured, automod approves the first one
+            self.get("/_internal/automod")
+            self.assertEquals(len(self.emails), 1)
+
+            # If configured more openly, it approves all.
+            self.post("/moderation", data={
+                "csrf_token": self.csrf_token("/moderation"),
+                "automod": "true",
+                "blacklist": "",
+                "min_delay": "0",
+            })
+
+            self.get("/_internal/automod")
+            self.assertEquals(len(self.emails), 2)

--- a/caravel/tests/test_automod_automod_expect.txt
+++ b/caravel/tests/test_automod_automod_expect.txt
@@ -1,0 +1,23 @@
+New Listing
+Logged in as
+admin@uchicago.edu
+My Listings
+Logout
+Title of ☆D
+apartments
+Posted now by
+marycole396@yahoo.com .
+Price: $3.44
+Body of ☆D
+Moderate Listing
+Approve
+Delete
+Automatic Moderation
+Enable
+Disable
+Inquiry: Listing ☆B
+Sent now by
+buyer@foo.com .
+Moderate Inquiry
+Approve
+Delete

--- a/caravel/tests/test_automod_control_panel_expect.txt
+++ b/caravel/tests/test_automod_control_panel_expect.txt
@@ -1,0 +1,46 @@
+New Listing
+Logged in as
+foo@uchicago.edu
+My Listings
+Logout
+Your listing is awaiting moderation. We&#39;ll email you when it&#39;s up.
+Title of ☆D
+apartments
+Posted now by
+seller-d@uchicago.edu .
+Price: $3.44
+Body of ☆D
+Moderate Listing
+Approve
+Delete
+Automatic Moderation
+Enable
+Disable
+Inquiry: Listing ☆B
+Sent now by
+buyer@foo.com .
+Moderate Inquiry
+Approve
+Delete
+---
+New Listing
+Logged in as
+foo@uchicago.edu
+My Listings
+Logout
+Inquiry: Listing ☆B
+Sent now by
+buyer@foo.com .
+Moderate Inquiry
+Approve
+Delete
+Automatic Moderation
+Enable
+Disable
+---
+New Listing
+Logged in as
+foo@uchicago.edu
+My Listings
+Logout
+All done!

--- a/cron.yaml
+++ b/cron.yaml
@@ -9,3 +9,6 @@ cron:
   url: /_internal/nag_moderators
   schedule: every day 09:00
   timezone: "America/Chicago"
+- description: run automod
+  url: /_internal/automod
+  schedule: every 30 minutes 


### PR DESCRIPTION
Currently, moderations are approved by a human moderator (myself), who is hoping to graduate this quarter. The Auto-Moderator is a toggleable listing and inquiry approver that simulates a human moderator with some dumb blacklisting heuristics. By running it every hour, we can hopefully reduce the volume of listings to moderate.