### PR TITLE
Fix mismatched end tag

### DIFF
--- a/caravel/templates/moderation/automod.html
+++ b/caravel/templates/moderation/automod.html
@@ -32,5 +32,5 @@
     </p>
     <input type="submit" class="btn btn-success" value="Save"/>
     {% endif %}
-  </div>
+  </form>
 </div>


### PR DESCRIPTION
Currently https://marketplace.uchicago.edu/moderation does not work, because I am a dummy and did the tags wrong.

Old: https://marketplace.uchicago.edu/moderation
New: https://fix-mismatch-dot-caravel-code-reviews.appspot.com/moderation