### PR TITLE
Fix wonky redirects bug

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -5,6 +5,9 @@ version: 1
 threadsafe: yes
 
 handlers:
+- url: /_internal.*
+  script: caravel.app
+  login: admin
 - url: /static
   static_dir: caravel/static
   secure: always

--- a/caravel/controllers/listings.py
+++ b/caravel/controllers/listings.py
@@ -130,7 +130,8 @@ def show_disclaimer(response):
 
 @app.before_request
 def might_be_wrong_url():
-    if request.host == "hosted-caravel.appspot.com":
+    if (request.host == "hosted-caravel.appspot.com" and
+            request.remote_addr != "0.1.0.1"):
         return redirect(request.url.replace(
             "hosted-caravel.appspot.com", "marketplace.appspot.com"))
 

--- a/caravel/controllers/moderation.py
+++ b/caravel/controllers/moderation.py
@@ -91,9 +91,6 @@ def moderation_view():
 
 @app.route("/_internal/automod")
 def automod():
-    if not users.is_current_user_admin():
-        return "???"
-
     pending = itertools.chain(
         model.UnapprovedListing().query(),
         model.UnapprovedInquiry().query(),

--- a/caravel/daemons/delete_old_photos.py
+++ b/caravel/daemons/delete_old_photos.py
@@ -8,9 +8,6 @@ from google.appengine.api import users
 
 @app.route('/_internal/collect_garbage')
 def collect_garbage():
-    if not users.is_current_user_admin():
-        return "???"
-
     model.Photo.remove_old_photos()
 
     return "ok"

--- a/caravel/daemons/migration.py
+++ b/caravel/daemons/migration.py
@@ -18,9 +18,6 @@ def grouper(iterable, n, fillvalue=None):
 
 @app.route("/_internal/migrate_schema")
 def migrate_schema():
-    if not users.is_current_user_admin():
-        return "???"
-
     horizon = datetime.datetime.now() - model.Listing.MARK_AS_OLD_AFTER
 
     q = model.Listing.query(

--- a/caravel/daemons/nag_moderators.py
+++ b/caravel/daemons/nag_moderators.py
@@ -10,9 +10,6 @@ from google.appengine.api import users
 
 @app.route('/_internal/nag_moderators')
 def nag_moderators():
-    if not users.is_current_user_admin():
-        return "???"
-
     listings = list(model.UnapprovedListing().query())
     inquiries = list(model.UnapprovedInquiry().query())
     pending = listings + inquiries

--- a/caravel/templates/moderation/view.html
+++ b/caravel/templates/moderation/view.html
@@ -7,7 +7,12 @@
 {% block content %}
 <div class="container">
   {% if not listings and not inquiries %}
-    <h1 style="text-align:center">All done!</h1>
+    <div class="row">
+      <h1 style="text-align:center" class="col-md-9">All done!</h1>
+      <div class="col-md-3">
+        {% include "moderation/automod.html" %}
+      </div>
+    </div>
   {% endif %}
   {% for listing in listings %}
   <div class="row hide-after-first">
@@ -36,10 +41,15 @@
           <h3 class="panel-title">Moderate Listing</h3>
         </div>
         <div class="panel-body">
-          <a data-approve="{{ listing.key.urlsafe() }}"
+          <p>
+            <a data-approve="{{ listing.key.urlsafe() }}"
              class="btn btn-success">Approve</a>
-          <a data-deny="{{ listing.key.urlsafe() }}"
-             class="btn btn-danger">Delete</a>
+            <a data-deny="{{ listing.key.urlsafe() }}"
+               class="btn btn-danger">Delete</a>
+          </p>
+          <p><strong>{{loop.index}}</strong> of
+             <strong>{{listings|length}}</strong> listings,
+             plus {{inquiries|length}} inquiries.</p>
         </div>
       </div>
       {% if loop.first %}
@@ -67,6 +77,8 @@
              class="btn btn-success">Approve</a>
           <a data-deny="{{ inquiry.key.urlsafe() }}"
              class="btn btn-danger">Delete</a>
+          <p><strong>{{loop.index}}</strong> of 
+             <strong>{{inquiries|length}}</strong> inquiries.</p>
         </div>
       </div>
       {% if loop.first and not listings %}

--- a/caravel/tests/test_automod_automod_expect.txt
+++ b/caravel/tests/test_automod_automod_expect.txt
@@ -12,6 +12,9 @@ Body of ☆D
 Moderate Listing
 Approve
 Delete
+1 of
+1 listings,
+plus 1 inquiries.
 Automatic Moderation
 Enable
 Disable
@@ -21,3 +24,5 @@ buyer@foo.com .
 Moderate Inquiry
 Approve
 Delete
+1 of
+1 inquiries.

--- a/caravel/tests/test_automod_control_panel_expect.txt
+++ b/caravel/tests/test_automod_control_panel_expect.txt
@@ -13,6 +13,9 @@ Body of ☆D
 Moderate Listing
 Approve
 Delete
+1 of
+1 listings,
+plus 1 inquiries.
 Automatic Moderation
 Enable
 Disable
@@ -22,6 +25,8 @@ buyer@foo.com .
 Moderate Inquiry
 Approve
 Delete
+1 of
+1 inquiries.
 ---
 New Listing
 Logged in as
@@ -34,6 +39,8 @@ buyer@foo.com .
 Moderate Inquiry
 Approve
 Delete
+1 of
+1 inquiries.
 Automatic Moderation
 Enable
 Disable
@@ -44,3 +51,6 @@ foo@uchicago.edu
 My Listings
 Logout
 All done!
+Automatic Moderation
+Enable
+Disable


### PR DESCRIPTION
It looks like the problem for Cron was dumber than I thought: a Flask pre-filter that was constantly redirecting invocations off-site. WIth some patching (and manual `appcfg.py` to prod :[ ) I think I've finally fixed all the bugs.

We now have a working Marketplace auto moderator!