### PR TITLE
Tweak instance scheduling

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -38,3 +38,12 @@ skip_files:
 - ^(.*/)?.*/RCS/.*$
 - ^(.*/)?\..*$
 - ^.*venv.*$
+
+default_expiration: "2d"
+
+automatic_scaling:
+  min_idle_instances: 0
+  max_idle_instances: 1
+  min_pending_latency: "15s"
+  max_pending_latency: "15s"
+


### PR DESCRIPTION
Currently, we run more instances than we should. I think adding these flags will reduce the cost somewhat.

https://cloud.google.com/appengine/docs/python/config/appref#scaling_elements
